### PR TITLE
Fix fetch credentials on error to retry after 5 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Dependencies
 This library depends on the following libraries:
 
 * [iso8601][2]
-* [jsone][6]
+* [jsx][6]
 * [eini][3]
 
 Implementation
@@ -105,4 +105,4 @@ Copyright (C) 2018 by Mark R. Allen.
 [3]: https://github.com/aws-beam/eini
 [4]: src/aws_credentials_provider.erl
 [5]: https://github.com/aws-beam/aws-erlang-metadata
-[6]: https://github.com/sile/jsone
+[6]: https://github.com/talentdeficit/jsx

--- a/src/aws_credentials.erl
+++ b/src/aws_credentials.erl
@@ -12,7 +12,7 @@
 %% We make new credentials available at least five minutes prior to the
 %% expiration of the old credentials.
 -define(ALERT_BEFORE_EXPIRY, 300). % 5 minutes
--define(RETRY_DELAY, 5000). % 5 seconds
+-define(RETRY_DELAY, 5). % 5 seconds
 -define(GREGORIAN_TO_EPOCH_SECONDS, 62167219200).
 
 -ifdef(OTP_RELEASE).

--- a/src/aws_credentials_httpc.erl
+++ b/src/aws_credentials_httpc.erl
@@ -5,7 +5,7 @@
 %%
 %% On errors, there will be a number of attempts with a delay equal to 100
 %% milliseconds times the number of tries minus tries left. (So the first
-%% delay would be 100 millseconds. The second delay would be 200 milliseconds,
+%% delay would be 100 milliseconds. The second delay would be 200 milliseconds,
 %% and so on...)
 %% @end
 
@@ -16,7 +16,7 @@
 -define(TIMEOUT, 10000). % 10 sec
 -define(CONNECT_TIMEOUT, 3000). % 3 sec
 -define(DEFAULT_TRIES, 3).
--define(DELAY, 100). % 100 microseconds
+-define(DELAY, 100). % 100 milliseconds
 
 start() ->
     inets:start(httpc, [{profile, ?PROFILE}]).


### PR DESCRIPTION
This PR tries to fix 3 issues:

* Replace jsone with jsx references on README
* Update `RETRY_DELAY` macro to be `5` seconds rather than `5000` which then gets multiplied with 1000 and ends up retrying after 1+ hour in case of an error while fetching credentials
* Minor typos