### PR TITLE
Fix environment variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ can change the list of modules in your erlang environment variables as in
 this example:
 
 ```erlang
-  {aws_credentials, [{credential_provider, [aws_credentials_ecs]}]
+  {aws_credentials, [{credential_providers, [aws_credentials_ecs]}]
   },
 ```
 


### PR DESCRIPTION
The README was pointing to an incorrect environment variable, which
was unused and had no effect on the application configuration.