### PR TITLE
Expose ways to pass options to providers

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,6 +14,10 @@
     , [ { deps
         , [meck]
         }
+      , { erl_opts, [ nowarn_export_all
+                    , nowarn_missing_spec_all
+                    ]
+        }
       ]
     }
   ]

--- a/src/aws_credentials.erl
+++ b/src/aws_credentials.erl
@@ -175,8 +175,8 @@ fetch_credentials(Options) ->
     catch E:R:ST when ShouldCatch ->
             ?LOG_INFO("aws_credentials ignoring exception ~p:~p (~p)~n",
                       [E, R, ST]),
-            setup_callback(?RETRY_DELAY),
-            {ok, undefined}
+            Ref = setup_callback(?RETRY_DELAY),
+            {ok, undefined, Ref}
     end.
 
 -spec setup_update_callback('infinity' | binary() | integer()) -> reference().

--- a/src/aws_credentials.erl
+++ b/src/aws_credentials.erl
@@ -189,7 +189,7 @@ setup_update_callback(Expires) when is_integer(Expires) ->
 
 -spec setup_callback(pos_integer()) -> reference().
 setup_callback(Seconds) ->
-    erlang:send_after(Seconds * 1000, self(), refresh_client).
+    erlang:send_after(Seconds * 1000, self(), refresh_credentials).
 
 -spec seconds_until_timestamp(binary()) -> integer().
 seconds_until_timestamp(Timestamp) ->

--- a/src/aws_credentials.erl
+++ b/src/aws_credentials.erl
@@ -179,7 +179,7 @@ fetch_credentials(Options) ->
             {ok, undefined}
     end.
 
--spec setup_update_callback('infinity' | binary() | integer()) -> ok.
+-spec setup_update_callback('infinity' | binary() | integer()) -> reference().
 setup_update_callback(infinity) -> ok;
 setup_update_callback(Expires) when is_binary(Expires) ->
     RefreshAfter = seconds_until_timestamp(Expires) - ?ALERT_BEFORE_EXPIRY,

--- a/src/aws_credentials_provider.erl
+++ b/src/aws_credentials_provider.erl
@@ -29,7 +29,7 @@
 
 -export([fetch/0, fetch/1]).
 
--type options() :: proplists:proplist().
+-type options() :: #{provider() => map()}.
 -type expiration() :: binary() | pos_integer() | infinity.
 -type provider() :: aws_credentials_env
                   | aws_credentials_file
@@ -59,13 +59,11 @@ fetch(Options) ->
 -spec evaluate_providers([provider() | {provider(), options()}], []) ->
         {'error', no_credentials} | aws_credentials:credentials().
 evaluate_providers([], _Options) -> {error, no_credentials};
-evaluate_providers([Provider|Providers], Options) when is_atom(Provider) ->
-  evaluate_providers([{Provider, []}|Providers], Options);
-evaluate_providers([ {Provider, ProviderOpts} | T ], Options) ->
-    case Provider:fetch(ProviderOpts ++ Options) of
+evaluate_providers([ Provider | Providers ], Options) ->
+    case Provider:fetch(Options) of
         {error, _} = Error ->
             ?LOG_ERROR("Provider ~p reports ~p", [Provider, Error]),
-            evaluate_providers(T, Options);
+            evaluate_providers(Providers, Options);
         Credentials -> Credentials
     end.
 

--- a/test/aws_credentials_providers_SUITE.erl
+++ b/test/aws_credentials_providers_SUITE.erl
@@ -51,8 +51,8 @@ init_per_group(GroupName, Config) ->
   Context = setup_provider(GroupName),
   Provider = provider(GroupName),
   ProviderOpts = provider_opts(GroupName, Config),
-  application:set_env(aws_credentials, credential_providers,
-                      [{Provider, ProviderOpts}]),
+  application:set_env(aws_credentials, credential_providers, [Provider]),
+  application:set_env(aws_credentials, provider_options, ProviderOpts),
   {ok, Started} = application:ensure_all_started(aws_credentials),
   [{started, Started}, {context, Context}|Config].
 
@@ -92,13 +92,13 @@ provider(GroupName) ->
 provider_opts(file, Config) ->
   DataDir = ?config(data_dir, Config),
   CredentialsPath = filename:join([DataDir, "credentials"]),
-  [{<<"credential_path">>, CredentialsPath}];
+  #{credential_path => CredentialsPath};
 provider_opts(ec2, _Config) ->
-  [];
+  #{};
 provider_opts(env, _Config) ->
-  [];
+  #{};
 provider_opts(ecs, _Config) ->
-  [].
+  #{}.
 
 group_name(Config) ->
   GroupProperties = ?config(tc_group_properties, Config),


### PR DESCRIPTION
Problem to solve: Users need a way to pass options to providers and there is currently no way to do so.

Solution: Add a new application environment variable `provider_options` which gets looked up before credentials are pulled. Also, add two new functions, `force_credentials_refresh/0` which uses the options given in the application environment (if any), and `force_credentials_refresh/1` which takes an explicit Options parameter as its argument. This parameter may or may not be the same as what's in the environment. We make _no_ attempt to merge the two at all - if upstream people want to open that can of worms, let them.

TODO: I'd like to add function specs as good documentation, and general code hygiene.