### PR TITLE
provider options should default to map instead of list

### DIFF
--- a/src/aws_credentials.erl
+++ b/src/aws_credentials.erl
@@ -102,7 +102,7 @@ get_credentials() ->
 %% options if any).
 -spec force_credentials_refresh() -> credentials() | {error, any()}.
 force_credentials_refresh() ->
-    ProviderOptions = application:get_env(aws_credentials, provider_options, []),
+    ProviderOptions = application:get_env(aws_credentials, provider_options, #{}),
     force_credentials_refresh(ProviderOptions).
 
 %% @doc Force a credentials update, passing options (which possibly override
@@ -118,7 +118,7 @@ force_credentials_refresh(Options) ->
 
 -spec init(_) -> {'ok', state()}.
 init(_Args) ->
-    ProviderOptions = application:get_env(aws_credentials, provider_options, []),
+    ProviderOptions = application:get_env(aws_credentials, provider_options, #{}),
     {ok, C, T} = fetch_credentials(ProviderOptions),
     {ok, #state{credentials=C, tref=T}}.
 
@@ -145,7 +145,7 @@ handle_cast(Message, State) ->
 
 -spec handle_info(any(), state()) -> {'noreply', state()}.
 handle_info(refresh_credentials, State) ->
-    ProviderOptions = application:get_env(aws_credentials, provider_options, []),
+    ProviderOptions = application:get_env(aws_credentials, provider_options, #{}),
     {ok, C, T} = fetch_credentials(ProviderOptions),
     {noreply, State#state{credentials=C, tref=T}};
 handle_info(Message, State) ->


### PR DESCRIPTION
Using this with elixir, if I don't configure the `provider_options` param, I get this error on startup:

```
** (Mix) Could not start application aws_credentials: :aws_credentials_app.start(:normal, []) returned an error: shutdown: failed to start child: :aws_credentials
    ** (EXIT) an exception was raised:
        ** (BadMapError) expected a map, got: []
            (stdlib 3.14) maps.erl:188: :maps.get(:credential_path, [], '/.aws/credentials')
            (aws_credentials 0.0.1) /srv/admin/deps/aws_credentials/src/aws_credentials_file.erl:38: :aws_credentials_file.does_credentials_file_exist/1
            (aws_credentials 0.0.1) /srv/admin/deps/aws_credentials/src/aws_credentials_file.erl:28: :aws_credentials_file.fetch/1
            (aws_credentials 0.0.1) /srv/admin/deps/aws_credentials/src/aws_credentials_provider.erl:63: :aws_credentials_provider.evaluate_providers/2
            (aws_credentials 0.0.1) /srv/admin/deps/aws_credentials/src/aws_credentials.erl:172: :aws_credentials.fetch_credentials/1
            (aws_credentials 0.0.1) /srv/admin/deps/aws_credentials/src/aws_credentials.erl:122: :aws_credentials.init/1
            (stdlib 3.14) gen_server.erl:417: :gen_server.init_it/2
            (stdlib 3.14) gen_server.erl:385: :gen_server.init_it/6
```

Workaround: explicitly configure `provider_options` with an empty map; in elixir:

```
config :aws_credentials, :provider_options, %{}
```