### PR TITLE
include potential session token from credentials file

### DIFF
--- a/src/aws_credentials_file.erl
+++ b/src/aws_credentials_file.erl
@@ -67,5 +67,6 @@ parse_file(Path, Options) ->
         Profile ->
             {ok, aws_credentials:make_map(?MODULE,
                                           maps:get(<<"aws_access_key_id">>, Profile),
-                                          maps:get(<<"aws_secret_access_key">>, Profile)), infinity}
+                                          maps:get(<<"aws_secret_access_key">>, Profile),
+                                          maps:get(<<"aws_session_token">>, Profile, "")), infinity}
     end.

--- a/src/aws_credentials_file.erl
+++ b/src/aws_credentials_file.erl
@@ -65,8 +65,15 @@ parse_file(Path, Options) ->
     case maps:get(Desired, Profiles, false) of
         false -> {error, {desired_profile_not_found, Desired}};
         Profile ->
-            {ok, aws_credentials:make_map(?MODULE,
-                                          maps:get(<<"aws_access_key_id">>, Profile),
-                                          maps:get(<<"aws_secret_access_key">>, Profile),
-                                          maps:get(<<"aws_session_token">>, Profile, "")), infinity}
+            case maps:is_key(<<"aws_session_token">>, Profile) of
+              true ->
+                  {ok, aws_credentials:make_map(?MODULE,
+                                              maps:get(<<"aws_access_key_id">>, Profile),
+                                              maps:get(<<"aws_secret_access_key">>, Profile),
+                                              maps:get(<<"aws_session_token">>, Profile)), infinity};
+              false ->
+                {ok, aws_credentials:make_map(?MODULE,
+                                              maps:get(<<"aws_access_key_id">>, Profile),
+                                              maps:get(<<"aws_secret_access_key">>, Profile)), infinity}
+            end
     end.

--- a/src/aws_credentials_file.erl
+++ b/src/aws_credentials_file.erl
@@ -70,10 +70,12 @@ parse_file(Path, Options) ->
                   {ok, aws_credentials:make_map(?MODULE,
                                               maps:get(<<"aws_access_key_id">>, Profile),
                                               maps:get(<<"aws_secret_access_key">>, Profile),
-                                              maps:get(<<"aws_session_token">>, Profile)), infinity};
+                                              maps:get(<<"aws_session_token">>, Profile)),
+                   infinity};
               false ->
                 {ok, aws_credentials:make_map(?MODULE,
                                               maps:get(<<"aws_access_key_id">>, Profile),
-                                              maps:get(<<"aws_secret_access_key">>, Profile)), infinity}
+                                              maps:get(<<"aws_secret_access_key">>, Profile)),
+                 infinity}
             end
     end.


### PR DESCRIPTION
The AWS credentials file may have a `aws_session_token` key that is needed in the AWS client for auth.  This change retrieves that and includes it in the AWS.Client structure to support these use-cases