### PR TITLE
Add support for region env without token env

### DIFF
--- a/src/aws_credentials_env.erl
+++ b/src/aws_credentials_env.erl
@@ -41,6 +41,12 @@ fetch(_Options) ->
                                   is_binary(T) ->
             {ok, aws_credentials:make_map(?MODULE, K, S, T), infinity};
 
+        {K, S, undefined, R} when is_binary(K),
+                                  is_binary(S),
+                                  is_binary(R) ->
+            Credentials = aws_credentials:make_map(?MODULE, K, S),
+            {ok, maps:put(region, R, Credentials), infinity};
+
         {K, S, T, R} when is_binary(K),
                           is_binary(S),
                           is_binary(T),


### PR DESCRIPTION
This is a particular case when you have `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and (`AWS_DEFAULT_REGION` or `AWS_REGION`) set, but no token.

Does it make sense? Thanks in advance for the feedback.