### PR TITLE
Fix force_credentials_refresh/0 raising Argument Error on infinity timeout

### DIFF
--- a/src/aws_credentials.erl
+++ b/src/aws_credentials.erl
@@ -132,7 +132,10 @@ handle_call(get_credentials, _From, State=#state{credentials=C}) ->
     {reply, C, State};
 handle_call({force_refresh, Options}, _From, State=#state{tref=T}) ->
     {ok, C, NewT} = fetch_credentials(Options),
-    erlang:cancel_timer(T),
+    case is_reference(T) of
+        true -> erlang:cancel_timer(T);
+        false -> ok
+    end,
     {reply, C, State#state{credentials=C, tref=NewT}};
 handle_call(Args, _From, State) ->
     ?LOG_WARNING("Unknown call: ~p~n", [Args], #{domain => [aws_credentials]}),


### PR DESCRIPTION
Resolves https://github.com/aws-beam/aws_credentials/issues/41

if `force_credentials_refresh` is called multiple times with an infinity timeout, ArgumentError is thrown.