### PR TITLE
Remove / (forward slash) from the end of EC2 metadata token API URL

### DIFF
--- a/src/aws_credentials_ec2.erl
+++ b/src/aws_credentials_ec2.erl
@@ -4,7 +4,7 @@
 -behaviour(aws_credentials_provider).
 
 -define(SESSION_TOKEN_URL,
-        "http://169.254.169.254/latest/api/token/").
+        "http://169.254.169.254/latest/api/token").
 -define(SESSION_TOKEN_TTL_HEADER,
         "x-aws-ec2-metadata-token-ttl-seconds").
 -define(SESSION_TOKEN_TTL_SECONDS,

--- a/test/aws_credentials_providers_SUITE.erl
+++ b/test/aws_credentials_providers_SUITE.erl
@@ -229,7 +229,7 @@ teardown_provider(Context) ->
 mock_httpc_request_ec2(Method, Request, HTTPOptions, Options, Profile) ->
   Headers = [{"X-aws-ec2-metadata-token", ?DUMMY_SESSION_TOKEN}],
   case Request of
-    {"http://169.254.169.254/latest/api/token/", _Headers} ->
+    {"http://169.254.169.254/latest/api/token", _Headers} ->
       {ok, response('session-token')};
     {"http://169.254.169.254/latest/meta-data/iam/security-credentials/", Headers} ->
       {ok, response('security-credentials')};


### PR DESCRIPTION
Remove / (forward slash) from the end of EC2 metadata token API URL as it is causing 403 forbidden error response from EC2.

Fixes: https://github.com/aws-beam/aws_credentials/issues/47