### PR TITLE
Allow the EC2 provider to return `{error, _}` as promised by the behaviour

### DIFF
--- a/src/aws_credentials_ec2.erl
+++ b/src/aws_credentials_ec2.erl
@@ -56,7 +56,7 @@ request_headers({error, _Error} = Error) -> Error;
 request_headers({ok, SessionToken}) ->
   SessionTokenString = binary:bin_to_list(SessionToken),
   RequestHeaders = [{?SESSION_TOKEN_HEADER, SessionTokenString}],
-    {ok, RequestHeaders}.
+  {ok, RequestHeaders}.
 
 -spec fetch_role({error, _}
                | {ok, request_headers()}) ->
@@ -76,10 +76,10 @@ fetch_role({ok, RequestHeaders}) ->
                    | {ok, request_headers()}) ->
         {error, ec2_metadata_unavailable}
       | {error, _}
-      | {ok, {AccessKeyID :: binary(),
-              SecretAccessKey :: binary(),
-              ExpirationTime :: binary(),
-              Token :: binary()}}.
+      | {ok, {aws_credentials:access_key_id(),
+              aws_credentials:secret_access_key(),
+              aws_credentials_provider:expiration(),
+              aws_credentials:token()}}.
 fetch_metadata({error, _Error} = Error, _RequestHeadersR) -> Error;
 fetch_metadata(_RoleR, {error, _Error} = Error) -> Error;
 fetch_metadata({ok, Role}, {ok, RequestHeaders}) ->
@@ -88,9 +88,9 @@ fetch_metadata({ok, Role}, {ok, RequestHeaders}) ->
       {ok, 200, Body, _Headers} ->
         Map = jsx:decode(Body),
         {ok, {maps:get(<<"AccessKeyId">>, Map),
-         maps:get(<<"SecretAccessKey">>, Map),
-         maps:get(<<"Expiration">>, Map),
-         maps:get(<<"Token">>, Map)}};
+              maps:get(<<"SecretAccessKey">>, Map),
+              maps:get(<<"Expiration">>, Map),
+              maps:get(<<"Token">>, Map)}};
        _Other -> {error, ec2_metadata_unavailable}
      end.
 
@@ -98,7 +98,7 @@ fetch_metadata({ok, Role}, {ok, RequestHeaders}) ->
                    | {ok, request_headers()}) ->
         {error, ec2_document_unavailable}
       | {error, _}
-      | {ok, binary()}.
+      | {ok, aws_credentials:region()}.
 fetch_document({error, _Error} = Error) -> Error;
 fetch_document({ok, RequestHeaders}) ->
     case aws_credentials_httpc:request(get, ?DOCUMENT_URL, RequestHeaders) of
@@ -110,14 +110,14 @@ fetch_document({ok, RequestHeaders}) ->
     end.
 
 -spec make_map({error, _}
-             | {ok, {AccessKeyID :: binary(),
-                     SecretAccessKey :: binary(),
-                     ExpirationTime :: binary(),
-                     Token :: binary()}},
+             | {ok, {aws_credentials:access_key_id(),
+                     aws_credentials:secret_access_key(),
+                     aws_credentials_provider:expiration(),
+                     aws_credentials:token()}},
                {error, _}
-             | {ok, Region :: binary()}) ->
+             | {ok, aws_credentials:region()}) ->
         {error, _}
-      | {ok, aws_credentials:credentials(), ExpirationTime :: binary()}.
+      | {ok, aws_credentials:credentials(), aws_credentials_provider:expiration()}.
 make_map({error, _Error} = Error, _DocumentR) -> Error;
 make_map(_MetadataR, {error, _Error} = Error) -> Error;
 make_map({ok, {AccessKeyID, SecretAccessKey, ExpirationTime, Token}}, {ok, Region}) ->

--- a/src/aws_credentials_ec2.erl
+++ b/src/aws_credentials_ec2.erl
@@ -23,10 +23,10 @@
 -type request_header() :: {field(), value()}.
 -type request_headers() :: [request_header()].
 
--type non_200(Tag) :: {Tag, {non_200,
-                             aws_credentials_httpc:status_code(),
-                             aws_credentials_httpc:body(),
-                             aws_credentials_httpc:headers()}}
+-type not200(Tag) :: {Tag, {not200,
+                            aws_credentials_httpc:status_code(),
+                            aws_credentials_httpc:body(),
+                            aws_credentials_httpc:headers()}}
                     | {Tag, aws_credentials_httpc:response_error()}.
 
 -export([fetch/1]).
@@ -45,13 +45,13 @@ fetch(_Options) ->
     make_map(MetadataR, DocumentR).
 
 -spec fetch_session_token() ->
-        {error, non_200(ec2_session_token_unavailable)}
+        {error, not200(ec2_session_token_unavailable)}
       | {ok, session_token()}.
 fetch_session_token() ->
   RequestHeaders = [{?SESSION_TOKEN_TTL_HEADER, ?SESSION_TOKEN_TTL_SECONDS}],
   case aws_credentials_httpc:request(put, ?SESSION_TOKEN_URL, RequestHeaders) of
     {ok, 200, Body, _Headers} -> {ok, Body};
-    Other -> {error, non_200(ec2_session_token_unavailable, Other)}
+    Other -> {error, not200(ec2_session_token_unavailable, Other)}
   end.
 
 -spec request_headers({error, _}
@@ -66,21 +66,21 @@ request_headers({ok, SessionToken}) ->
 
 -spec fetch_role({error, _}
                | {ok, request_headers()}) ->
-        {error, non_200(ec2_role_unavailable)}
+        {error, not200(ec2_role_unavailable)}
       | {error, _}
       | {ok, role()}.
 fetch_role({error, _Error} = Error) -> Error;
 fetch_role({ok, RequestHeaders}) ->
     case aws_credentials_httpc:request(get, ?CREDENTIAL_URL, RequestHeaders) of
       {ok, 200, Body, _Headers} -> {ok, Body};
-      Other -> {error, non_200(ec2_role_unavailable, Other)}
+      Other -> {error, not200(ec2_role_unavailable, Other)}
     end.
 
 -spec fetch_metadata({error, _}
                    | {ok, role()},
                      {error, _}
                    | {ok, request_headers()}) ->
-        {error, non_200(ec2_metadata_unavailable)}
+        {error, not200(ec2_metadata_unavailable)}
       | {error, _}
       | {ok, {aws_credentials:access_key_id(),
               aws_credentials:secret_access_key(),
@@ -97,12 +97,12 @@ fetch_metadata({ok, Role}, {ok, RequestHeaders}) ->
               maps:get(<<"SecretAccessKey">>, Map),
               maps:get(<<"Expiration">>, Map),
               maps:get(<<"Token">>, Map)}};
-       Other -> {error, non_200(ec2_metadata_unavailable, Other)}
+       Other -> {error, not200(ec2_metadata_unavailable, Other)}
      end.
 
 -spec fetch_document({error, _}
                    | {ok, request_headers()}) ->
-        {error, non_200(ec2_document_unavailable)}
+        {error, not200(ec2_document_unavailable)}
       | {error, _}
       | {ok, aws_credentials:region()}.
 fetch_document({error, _Error} = Error) -> Error;
@@ -111,7 +111,7 @@ fetch_document({ok, RequestHeaders}) ->
       {ok, 200, Body, _Headers} ->
         Map = jsx:decode(Body),
         {ok, maps:get(<<"region">>, Map)};
-      Other -> {error, non_200(ec2_document_unavailable, Other)}
+      Other -> {error, not200(ec2_document_unavailable, Other)}
     end.
 
 -spec make_map({error, _}
@@ -129,8 +129,8 @@ make_map({ok, {AccessKeyID, SecretAccessKey, ExpirationTime, Token}}, {ok, Regio
   Credentials = aws_credentials:make_map(?MODULE, AccessKeyID, SecretAccessKey, Token, Region),
   {ok, Credentials, ExpirationTime}.
 
--spec non_200(Tag, aws_credentials_httpc:response()) -> non_200(Tag).
-non_200(Tag, {ok, StatusCode, Body, Headers}) ->
-  {Tag, {non_200, StatusCode, Body, Headers}};
-non_200(Tag, {error, Error}) ->
+-spec not200(Tag, aws_credentials_httpc:response()) -> not200(Tag).
+not200(Tag, {ok, StatusCode, Body, Headers}) ->
+  {Tag, {not200, StatusCode, Body, Headers}};
+not200(Tag, {error, Error}) ->
   {Tag, Error}.


### PR DESCRIPTION
... thus avoiding a crash, but maintaining functionality (providers are tried in the defined order, as-was).

The code approach to not have a case-case-case-... spiral was inspired by Garrett Smith's awesome [Writing Quality Code in Erlang](https://www.youtube.com/watch?v=CQyt9Vlkbis).

This would also be a nifty candidate for `maybe`, but I'm not sure we want to force people to update to a very recent Erlang version just to benefit from this.

The gist of it is:

1. `fetch` now returns `{error, _}` as promised to the callback 😄
2. all `{error, _}` are explicit in starting with `ec2_`
3. function results cascade into other functions (the pattern the video mentions), which is why we see some `{error, _}` and not something more explicit (though do let me know if you prefer super-explicit and I'll change it accordingly)
4. we introduce a bunch of `case` expressions to avoid crashing
5. ~this is probably best viewed with `Hide whitespace` enabled~

Closes #36 