### PR TITLE
Allow accumulating errors instead of displaying them as they happen

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ Different credential providers may have other settings which you can use to
 change their behaviors.  See the documentation for each provider for more
 details.
 
+Error Logging
+-------------
+
+If you prefer to not log errors as they happen (the default behavior), but accumulate
+them for later, you can set erlang environment variable `log_errors_immediately` to
+`false` as in this example:
+
+```erlang
+  {aws_credentials, [{log_errors_immediately, false}]
+  },
+```
+
 License and copyright
 ---------------------
 This project is licensed under the terms of the Apache 2 license. It is a

--- a/src/aws_credentials_httpc.erl
+++ b/src/aws_credentials_httpc.erl
@@ -72,10 +72,10 @@ request(Method, URL, RequestHeaders, Tries, Remaining, Errs) ->
 
       Error ->
         NewRemaining = Remaining - 1,
-        ?LOG_ERROR("Error fetching URL (attempts left: "
-                   "~p of ~p) ~p: ~p.",
-                   [NewRemaining, Tries, URL, Error],
-                   #{domain => [aws_credentials]}),
+        String = "Error fetching URL (attempts left: ~p of ~p) ~p: ~p.",
+        Args = [NewRemaining, Tries, URL, Error],
+        Metadata = #{domain => [aws_credentials]},
+        aws_credentials:log_error(String, Args, Metadata),
         timer:sleep((Tries - NewRemaining) * ?DELAY),
         request(Method, URL, RequestHeaders, Tries, NewRemaining, [ Error | Errs ])
     end.


### PR DESCRIPTION
Closes #49.

The goal is to accumulate errors, instead of displaying them immediately, since one provider might fail, but a subsequent one might not (and the strategy is already chosen by the consumer, in any case).

We thus, accumulate errors to show in case of total failure, otherwise we display them as `info` as they go along (I'm thinking about those cases where there's an active wait and it seems something else might be stuck when it's not, actually).