### PR TITLE
Fix #52: Generate hexdocs so they're uploaded whenever a new package is published

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,9 +52,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: rebar3 cover
     - name: Produce Documentation
-      run: rebar3 edoc
+      run: rebar3 edoc || true
+    - name: Produce Documentation
+      run: rebar3 ex_doc || true
     - name: Publish Documentation
       uses: actions/upload-artifact@v1
       with:
         name: edoc
-        path: edoc
+        path: doc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Run EUnit Tests
         run: rebar3 eunit
 
+      - name: Generate docs
+        run: rebar3 ex_doc
+
       - uses: ncipollo/release-action@v1
         with:
           generateReleaseNotes: true

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ _plugins
 _tdeps
 logs
 _build
+doc

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,17 @@
 {erl_opts, [ debug_info
            , warn_missing_spec_all
            ]}.
-{edoc_opts, [{dir, "edoc"}, {preprocess, true}]}.
+{project_plugins, [rebar3_hex, rebar3_ex_doc]}.
+{hex, [{doc, #{provider => ex_doc}}]}.
+{ex_doc, [
+    {extras, [
+          {'README.md', #{title => <<"Overview">>}},
+          {'LICENSE.md', #{title => <<"License">>}}
+    ]},
+    {main, <<"readme">>},
+    {homepage_url, <<"https://github.com/aws-beam/aws_credentials">>},
+    {source_url, <<"https://github.com/aws-beam/aws_credentials">>}
+]}.
 {deps, [ jsx
        , iso8601
        , {eini, "2.2.3", {pkg, eini_beam}} %% eini_beam should look like plain eini

--- a/src/aws_credentials_ec2.erl
+++ b/src/aws_credentials_ec2.erl
@@ -33,7 +33,7 @@
 
 -spec fetch(aws_credentials_provider:options()) ->
         {error, _}
-      | {ok, aws_credentials_provider:credentials(), aws_credentials_provider:expiration()}.
+      | {ok, aws_credentials:credentials(), aws_credentials_provider:expiration()}.
 fetch(_Options) ->
     % Fetch the IMDS session token and convert it to the request headers.
     % Then pass the request headers to subsequent IMDS requests.

--- a/src/aws_credentials_ecs.erl
+++ b/src/aws_credentials_ecs.erl
@@ -6,7 +6,7 @@
 -export([fetch/1]).
 
 -spec fetch(any()) ->
-        {ok, aws_credentials_provider:credentials(), aws_credentials_provider:expiration()} |
+        {ok, aws_credentials:credentials(), aws_credentials_provider:expiration()} |
         {error, any()}.
 fetch(_Options) ->
   RelativeUri = os:getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"),


### PR DESCRIPTION
Dry run is passing at least:
```shell
rebar3 hex publish --dry-run
===> Verifying dependencies...
Local Password:
Publishing aws_credentials 0.1.11+build.151.ref84097a4 to hexpm
  Description: AWS credentials application for Erlang
  Dependencies:
    jsx ~>3.0.0
    iso8601 ~>1.3.1
    eini_beam ~>2.2.3
  Included files:
    LICENSE.md
    README.md
    rebar.config
    rebar.lock
    src
    src/aws_credentials.app.src
    src/aws_credentials.erl
    src/aws_credentials_app.erl
    src/aws_credentials_ec2.erl
    src/aws_credentials_ecs.erl
    src/aws_credentials_env.erl
    src/aws_credentials_file.erl
    src/aws_credentials_httpc.erl
    src/aws_credentials_provider.erl
    src/aws_credentials_sup.erl
  Licenses: Apache-2.0
  Links:
    GitHub: https://github.com/aws-beam/aws_credentials.git
  Build tools: rebar3
Be aware, you are publishing to the public Hexpm repository.
Before publishing, please read Hex CoC: https://hex.pm/policies/codeofconduct
Proceed? ("Y")> Y
===> --dry-run enabled : will not publish package.
===> Analyzing applications...
===> Compiling aws_credentials
===> Running edoc for aws_credentials
===> Running ex_doc for aws_credentials
===> --dry-run enabled : will not publish docs.
```