### PR TITLE
Log retries as info

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,18 +93,6 @@ Different credential providers may have other settings which you can use to
 change their behaviors.  See the documentation for each provider for more
 details.
 
-Error Logging
--------------
-
-If you prefer to not log errors as they happen (the default behavior), but accumulate
-them for later, you can set erlang environment variable `log_errors_immediately` to
-`false` as in this example:
-
-```erlang
-  {aws_credentials, [{log_errors_immediately, false}]
-  },
-```
-
 License and copyright
 ---------------------
 This project is licensed under the terms of the Apache 2 license. It is a

--- a/src/aws_credentials.erl
+++ b/src/aws_credentials.erl
@@ -35,7 +35,6 @@
         , make_map/3
         , make_map/4
         , make_map/5
-        , log_error/3
         ]).
 
 -record(state, { credentials = undefined :: map()
@@ -169,13 +168,6 @@ format_status(_, [_PDict, State]) ->
 %%====================================================================
 %% Internal functions
 %%====================================================================
-
--spec log_error(String :: unicode:chardata(), Args :: [term()], logger:metadata()) -> ok.
-log_error(String, Args, Metadata) ->
-    case application:get_env(aws_credentials, log_errors_immediately, true) of
-        true -> ?LOG_ERROR(String, Args, Metadata);
-        false -> ?LOG_INFO(String, Args, Metadata)
-    end.
 
 -spec fetch_credentials(aws_credentials_provider:options()) ->
         {ok, credentials() | 'undefined', reference() | 'undefined'}.

--- a/src/aws_credentials_httpc.erl
+++ b/src/aws_credentials_httpc.erl
@@ -74,10 +74,10 @@ request(Method, URL, RequestHeaders, Tries, Remaining, Errs) ->
 
       Error ->
         NewRemaining = Remaining - 1,
-        String = "Error fetching URL (attempts left: ~p of ~p) ~p: ~p.",
-        Args = [NewRemaining, Tries, URL, Error],
-        Metadata = #{domain => [aws_credentials]},
-        aws_credentials:log_error(String, Args, Metadata),
+        ?LOG_INFO("Error fetching URL (attempts left: "
+                  "~p of ~p) ~p: ~p.",
+                  [NewRemaining, Tries, URL, Error],
+                  #{domain => [aws_credentials]}),
         timer:sleep((Tries - NewRemaining) * ?DELAY),
         request(Method, URL, RequestHeaders, Tries, NewRemaining, [ Error | Errs ])
     end.


### PR DESCRIPTION
Those will be logged as errors later if all providers fail.

Closes #58.