### PR TITLE
pass verify_none to httpc:request

### DIFF
--- a/src/aws_credentials_httpc.erl
+++ b/src/aws_credentials_httpc.erl
@@ -84,8 +84,10 @@ request(Method, URL, RequestHeaders, Tries, Remaining, Errs) ->
 
 -spec make_request(method(), url(), [header()]) -> {ok, httpc_result()} | {error, any()}.
 make_request(Method, URL, RequestHeaders) ->
+    HttpOptions = [{timeout, ?TIMEOUT},
+                   {connect_timeout, ?CONNECT_TIMEOUT},
+                   {ssl, [{verify, verify_none}]}],
     httpc:request(Method, {URL, RequestHeaders},
-                  [{timeout, ?TIMEOUT},
-                   {connect_timeout, ?CONNECT_TIMEOUT}], % HTTP options
+                  HttpOptions,
                   [{body_format, binary}], % options
                   ?PROFILE).


### PR DESCRIPTION
The `ssl` changes in OTP-26 mean that any code that doesn't specify `verify_none` will default to `verify_peer`, and unless certs are passed in you get hard errors. This also affects `httpc:request`. Update uses of the latter to explicitly pass in `verify_none`.