### PR TITLE
Bump eini_beam package to 2.2.4

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
 ]}.
 {deps, [ jsx
        , iso8601
-       , {eini, "2.2.3", {pkg, eini_beam}} %% eini_beam should look like plain eini
+       , {eini, "2.2.4", {pkg, eini_beam}} %% eini_beam should look like plain eini
        ]}.
 
 {ct_opts, [{ct_hooks, [cth_readable_failonly, cth_readable_shell]}]}.


### PR DESCRIPTION
Brings in: https://github.com/aws-beam/eini-beam/pull/6