### PR TITLE
Keep previous credentials when refresh fails

### DIFF
--- a/src/aws_credentials.erl
+++ b/src/aws_credentials.erl
@@ -131,15 +131,12 @@ terminate(_Reason, _State) ->
 handle_call(get_credentials, _From, State=#state{credentials=C}) ->
     {reply, C, State};
 handle_call({force_refresh, Options}, _From, State=#state{tref=T}) ->
-    Result = fetch_credentials(Options),
+    {ok, C, NewT} = fetch_credentials(Options),
     case is_reference(T) of
         true -> erlang:cancel_timer(T);
         false -> ok
     end,
-    case Result of
-        {ok, undefined, NewT} -> {reply, undefined, State#state{tref=NewT}};
-        {ok, C, NewT} -> {reply, C, State#state{credentials=C, tref=NewT}}
-    end;
+    {reply, C, State#state{credentials=C, tref=NewT}};
 handle_call(Args, _From, State) ->
     ?LOG_WARNING("Unknown call: ~p~n", [Args], #{domain => [aws_credentials]}),
     {noreply, State}.


### PR DESCRIPTION
The current version of `aws_credentials` seems to have a bug around refreshing credentials.

When refreshing fails, the stored credentials value is overwritten with `true`.

Reproduction:
```
$ rebar3 shell
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling aws_credentials
Erlang/OTP 26 [erts-14.1] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [jit:ns]

Eshell V14.1 (press Ctrl+G to abort, type help(). for help)
1> application:set_env(aws_credentials, provider_options, #{credential_path => "test/aws_credentials_providers_SUITE_data/"}). % ensures credentials to be loaded
ok
2> application:ensure_all_started(aws_credentials). % starts aws_credentials
{ok,[jsx,eini,iso8601,aws_credentials]}
3> application:set_env(aws_credentials, fail_if_unavailable, false). % overrides fail_if_unavailable (since it is set to true by rebar3 shell)
ok
4> aws_credentials:get_credentials(). % should show credentials
#{access_key_id => <<"dummy_access_key">>,
  credential_provider => aws_credentials_file,
  secret_access_key => <<"dummy_secret_access_key">>}
5> application:set_env(aws_credentials, provider_options, #{credential_path => "fail"}). % changes options to make refresh fail
ok
6> [{_, Pid, _, _}] = supervisor:which_children(aws_credentials_sup). % get pid
[{aws_credentials,<0.403.0>,worker,[aws_credentials]}]
7> Pid ! refresh_credentials. % manually cause refresh by sending message
refresh_credentials
8> aws_credentials:get_credentials(). % timeout.
** exception exit: {timeout,{gen_server,call,
                                        [aws_credentials,get_credentials]}}
     in function  gen_server:call/2 (gen_server.erl, line 386)
9> aws_credentials:get_credentials(). % again. credential becam `true'
true
```

I suggest keeping the previous credentials when automatic refresh fails.
