### PR TITLE
Allow custom providers in provider() type

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ or a map of the shape:
 
 ```erlang
 #{
-  provider_source => Provider :: atom(),
+  provider_source => Provider :: module(),
   access_key_id => AccessKey :: binary(),
   secret_access_key => SecretKey :: binary(),
   token => Token :: binary(),

--- a/src/aws_credentials_provider.erl
+++ b/src/aws_credentials_provider.erl
@@ -1,7 +1,8 @@
 %% @doc This is the behaviour definition for a credential provider
 %% module and it iterates over a list of providers. You may set the
 %% `credential_providers` Erlang environment variable if you want to
-%% restrict checking only a certain subset of the default list.
+%% restrict checking only a certain subset of the default list or
+%% if you want to use your own custom providers.
 %%
 %% Default order of checking for credentials is:
 %% <ol>
@@ -34,7 +35,8 @@
 -type provider() :: aws_credentials_env
                   | aws_credentials_file
                   | aws_credentials_ecs
-                  | aws_credentials_ec2.
+                  | aws_credentials_ec2
+                  | module().
 -type error_log() :: [{provider(), term()}].
 -export_type([ options/0, expiration/0, provider/0 ]).
 


### PR DESCRIPTION
aws_credentials allows users to add custom providers.
However, the `aws_credentials_provider:provider()` type is currently limited to built-in module names
causing custom providers to be rejected by Dialyzer because their names are not listed in the `provider()` type.
Example:
```erlang
C = aws_credentials:make_map(my_provider_module, AccessKeyId, SecretAccessKey, Token),
                          %% ^ This atom is not in the `provider()' type, so Dialyzer rejects it.
```

This pull request adds the `module()` type to the `provider()` type, allowing custom providers to pass Dialyzer checks.
Additionally, I made some minor changes related to custom providers.
