### PR TITLE
Handle provider options as in the spec.

### DIFF
--- a/src/aws_credentials_ec2.erl
+++ b/src/aws_credentials_ec2.erl
@@ -31,7 +31,7 @@
 
 -export([fetch/1]).
 
--spec fetch(aws_credentials_provider:options()) ->
+-spec fetch(any()) ->
         {error, _}
       | {ok, aws_credentials:credentials(), aws_credentials_provider:expiration()}.
 fetch(_Options) ->

--- a/src/aws_credentials_provider.erl
+++ b/src/aws_credentials_provider.erl
@@ -30,7 +30,19 @@
 
 -export([fetch/0, fetch/1]).
 
--type options() :: #{provider() => map()}.
+%% `credential_path' and `profile' are treated as common options,
+%% and their values are inherited by `provider_options()'
+%% unless the same options exist in `provider_options()'.
+%% Note: This behaviour is for compatibility reason only, and
+%% do not add any other common options.
+-type options() :: #{ credential_path => string()
+                    , profile => binary()
+                    , provider() => provider_options()
+                    }.
+-type provider_options() :: #{ credential_path => string()
+                             , profile => binary()
+                             , any() => any()
+                             }.
 -type expiration() :: binary() | pos_integer() | infinity.
 -type provider() :: aws_credentials_env
                   | aws_credentials_file
@@ -40,7 +52,7 @@
 -type error_log() :: [{provider(), term()}].
 -export_type([ options/0, expiration/0, provider/0 ]).
 
--callback fetch(options()) ->
+-callback fetch(provider_options()) ->
   {ok, aws_credentials:credentials(), expiration()} | {error, any()}.
 
 -include_lib("kernel/include/logger.hrl").
@@ -74,7 +86,8 @@ evaluate_providers([], _Options, []) ->
 evaluate_providers([], _Options, Errors) when is_list(Errors) ->
     {error, lists:reverse(Errors)};
 evaluate_providers([ Provider | Providers ], Options, Errors) ->
-    case Provider:fetch(Options) of
+    ProviderOptions = get_provider_options(Provider, Options),
+    case Provider:fetch(ProviderOptions) of
         {error, _} = Error ->
             evaluate_providers(Providers, Options, [{Provider, Error} | Errors]);
         {ok, Credentials, Expiration} ->
@@ -87,3 +100,12 @@ get_env(Key, Default) ->
         undefined -> Default;
         {ok, Value} -> Value
     end.
+
+-spec get_provider_options(provider(), options()) -> provider_options().
+get_provider_options(Provider, Options) ->
+    ProviderOptions = maps:get(Provider, Options, #{}),
+    IsCommonOptions = fun(profile, _) -> true; (credential_path, _) -> true; (_, _) -> false end,
+    CommonOptions = maps:filter(IsCommonOptions, Options),
+    %% If an option exists in both ProviderOptions and CommonOptions,
+    %% the value in ProviderOptions should be adopted.
+    maps:merge(CommonOptions, ProviderOptions).


### PR DESCRIPTION
As mentioned in issue [#70](https://github.com/aws-beam/aws_credentials/issues/70), there is confusion around the `aws_credentials_provider:options()` type and usage.
I propose introducing the `aws_credentials_provider:provider_options()` type and passing it to each provider.

Additionally, I suggest two special options that are treated as "common options" for compatibility with current aws_credentials_file users.
I think there are three choices for handling this:

1. Introduce more "common options" in the future if needed.
2. Prohibit any further "common options," keeping them only for compatibility. (my current code)
3. Remove "common options," breaking compatibility.

I prefer option 3 if breaking compatibility is allowed.
I would appreciate your opinions in the comments. :bow: