### PR TITLE
Set fail_if_unavailable to false in .src file

### DIFF
--- a/src/aws_credentials.app.src
+++ b/src/aws_credentials.app.src
@@ -12,7 +12,7 @@
     iso8601
    ]},
   {env,[
-    {fail_if_unavailable, true}
+    {fail_if_unavailable, false}
   ]},
   {modules, []},
   {authors, ["Mark Allen"]},


### PR DESCRIPTION
We changed and documented the change of default to `fail_if_unavailable` in #60 but the change was not done to the .src file.