### PR TITLE
Add a provider to support EKS Pod Identity

### DIFF
--- a/src/aws_credentials_eks.erl
+++ b/src/aws_credentials_eks.erl
@@ -1,0 +1,46 @@
+%% @doc This provider looks up credential information from EKS Pod Identity
+%% @end
+-module(aws_credentials_eks).
+-behaviour(aws_credentials_provider).
+
+-define(AUTHORIZATION_HEADER, "authorization").
+
+-export([fetch/1]).
+
+-spec fetch(any()) ->
+        {ok, aws_credentials:credentials(), aws_credentials_provider:expiration()} |
+        {error, any()}.
+fetch(_Options) ->
+  FullUri = os:getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI"),
+  TokenFile = os:getenv("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"),
+  AuthToken = read_token(TokenFile),
+  Response = fetch_session_token(FullUri, AuthToken),
+  make_map(Response).
+
+-spec read_token(false | string()) -> {ok, string()} | {error, any()}.
+read_token(false) -> {error, no_credentials};
+read_token(Path) -> file:read_file(Path).
+
+-spec fetch_session_token(false | string(), {error, any()} | {ok, string()}) ->
+	{error, any()} | {ok, aws_credentials_httpc:status_code(),
+                            aws_credentials_httpc:body(),
+                            aws_credentials_httpc:headers()}.
+fetch_session_token(false, _AuthToken) -> {error, no_credentials};
+fetch_session_token(_FullUri, {error, _Error} = Error) -> Error;
+fetch_session_token(FullUri, {ok, AuthToken}) ->
+  aws_credentials_httpc:request(get, FullUri, [{?AUTHORIZATION_HEADER, AuthToken}]).
+
+
+-spec make_map({error, any()} | {ok, aws_credentials_httpc:status_code(),
+                            aws_credentials_httpc:body(),
+                            aws_credentials_httpc:headers()}) ->
+	{error, any()} | {ok, aws_credentials:credentials(), aws_credentials_provider:expiration()}.
+make_map({error, _Error} = Error) -> Error;
+make_map({ok, _Status, Body, _Headers}) ->
+  #{ <<"AccessKeyId">> := AccessKeyId
+   , <<"SecretAccessKey">> := SecretAccessKey
+   , <<"Token">> := Token
+   , <<"Expiration">> := Expiration
+  } = jsx:decode(Body),
+  Creds = aws_credentials:make_map(?MODULE, AccessKeyId, SecretAccessKey, Token),
+  {ok, Creds, Expiration}.

--- a/src/aws_credentials_eks.erl
+++ b/src/aws_credentials_eks.erl
@@ -7,9 +7,9 @@
 
 -export([fetch/1]).
 
--spec fetch(any()) ->
-        {ok, aws_credentials:credentials(), aws_credentials_provider:expiration()} |
-        {error, any()}.
+-spec fetch(aws_credentials_provider:options()) ->
+        {error, _}
+      | {ok, aws_credentials:credentials(), aws_credentials_provider:expiration()}.
 fetch(_Options) ->
   FullUri = os:getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI"),
   TokenFile = os:getenv("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"),
@@ -17,24 +17,27 @@ fetch(_Options) ->
   Response = fetch_session_token(FullUri, AuthToken),
   make_map(Response).
 
--spec read_token(false | string()) -> {ok, string()} | {error, any()}.
+-spec read_token(false | string()) -> {error, _} | {ok, binary()}.
 read_token(false) -> {error, no_credentials};
 read_token(Path) -> file:read_file(Path).
 
--spec fetch_session_token(false | string(), {error, any()} | {ok, string()}) ->
-	{error, any()} | {ok, aws_credentials_httpc:status_code(),
-                            aws_credentials_httpc:body(),
-                            aws_credentials_httpc:headers()}.
+-spec fetch_session_token(false | string(), {error, _} | {ok, string()}) ->
+        {error, _}
+      | {ok, aws_credentials_httpc:status_code(),
+              aws_credentials_httpc:body(),
+              aws_credentials_httpc:headers()}.
 fetch_session_token(false, _AuthToken) -> {error, no_credentials};
 fetch_session_token(_FullUri, {error, _Error} = Error) -> Error;
 fetch_session_token(FullUri, {ok, AuthToken}) ->
   aws_credentials_httpc:request(get, FullUri, [{?AUTHORIZATION_HEADER, AuthToken}]).
 
 
--spec make_map({error, any()} | {ok, aws_credentials_httpc:status_code(),
-                            aws_credentials_httpc:body(),
-                            aws_credentials_httpc:headers()}) ->
-	{error, any()} | {ok, aws_credentials:credentials(), aws_credentials_provider:expiration()}.
+-spec make_map({error, _}
+             | {ok, aws_credentials_httpc:status_code(),
+                    aws_credentials_httpc:body(),
+                    aws_credentials_httpc:headers()}) ->
+        {error, _}
+      | {ok, aws_credentials:credentials(), aws_credentials_provider:expiration()}.
 make_map({error, _Error} = Error) -> Error;
 make_map({ok, _Status, Body, _Headers}) ->
   #{ <<"AccessKeyId">> := AccessKeyId

--- a/src/aws_credentials_httpc.erl
+++ b/src/aws_credentials_httpc.erl
@@ -21,7 +21,7 @@
 
 -type httpc_result() :: {status_line(), [header()], body()}.
 -type status_line() :: {http_version(), status_code(), reason_phrase()}.
--type header() :: {string(), string()}.
+-type header() :: {string(), binary() | string()}.
 -type body() :: binary().
 -type http_version() :: string().
 -type status_code() :: non_neg_integer().

--- a/src/aws_credentials_provider.erl
+++ b/src/aws_credentials_provider.erl
@@ -36,6 +36,7 @@
                   | aws_credentials_file
                   | aws_credentials_ecs
                   | aws_credentials_ec2
+                  | aws_credentials_eks
                   | module().
 -type error_log() :: [{provider(), term()}].
 -export_type([ options/0, expiration/0, provider/0, error_log/0 ]).
@@ -48,7 +49,8 @@
 -define(DEFAULT_PROVIDERS, [aws_credentials_env,
                             aws_credentials_file,
                             aws_credentials_ecs,
-                            aws_credentials_ec2]).
+                            aws_credentials_ec2,
+                            aws_credentials_eks]).
 
 -spec fetch() ->
         {ok, aws_credentials:credentials(), expiration()} |

--- a/test/aws_credentials_providers_SUITE_data/eks/token
+++ b/test/aws_credentials_providers_SUITE_data/eks/token
@@ -1,0 +1,1 @@
+dummy-authorization-token


### PR DESCRIPTION
This PR adds a credential provider that can acquire credentials using the [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) system. This enables authenticating to AWS services from Kubernetes pods running in AWS EKS.

Licensing:
This contribution is made by employees of Mechanical Orchard, Inc. under the terms of the project’s license.