### PR TITLE
Implement a provider for web identity tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ sources in the following default order:
 3. An AWS [credentials file][1]
 4. ECS task credentials
 5. EC2 metadata
+6. EKS Pod Identity
+7. Web Identity
 
 Usage
 -----

--- a/rebar.config
+++ b/rebar.config
@@ -40,4 +40,6 @@
               , deprecated_functions
               ]}.
 
+{dialyzer, [{plt_extra_apps, [xmerl]}]}.
+
 {plugins, [ {rebar3_lint, "3.0.1"} ]}.

--- a/src/aws_credentials_provider.erl
+++ b/src/aws_credentials_provider.erl
@@ -37,6 +37,7 @@
                   | aws_credentials_ecs
                   | aws_credentials_ec2
                   | aws_credentials_eks
+                  | aws_credentials_web_identity
                   | module().
 -type error_log() :: [{provider(), term()}].
 -export_type([ options/0, expiration/0, provider/0, error_log/0 ]).
@@ -50,7 +51,8 @@
                             aws_credentials_file,
                             aws_credentials_ecs,
                             aws_credentials_ec2,
-                            aws_credentials_eks]).
+                            aws_credentials_eks,
+                            aws_credentials_web_identity]).
 
 -spec fetch() ->
         {ok, aws_credentials:credentials(), expiration()} |

--- a/src/aws_credentials_web_identity.erl
+++ b/src/aws_credentials_web_identity.erl
@@ -1,0 +1,66 @@
+%% @doc This provider looks up credential information from web identity token
+%% Environment parameters:
+%% <ul>
+%%   <li> &lt;&lt;"role_session_name"&gt;&gt; - this is provided to the credential fetch endpoint,
+%%   and will label the provided session with that name, see:
+%%   https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html#API_AssumeRoleWithWebIdentity_RequestParameters
+%%   By default this is `erlang_aws_credentials'</li>
+%% </ul>
+%% @end
+-module(aws_credentials_web_identity).
+-behaviour(aws_credentials_provider).
+
+-include_lib("xmerl/include/xmerl.hrl").
+
+-define(ASSUME_ROLE_URL,
+        "https://sts.amazonaws.com/?Action=AssumeRoleWithWebIdentity&Version=2011-06-15" ++
+        "&RoleArn=~s&WebIdentityToken=~s&RoleSessionName=~s").
+-define(DEFAULT_SESSION_NAME, "erlang_aws_credentials").
+
+-export([fetch/1]).
+
+-spec fetch(aws_credentials_provider:options()) ->
+        {error, _}
+      | {ok, aws_credentials:credentials(), aws_credentials_provider:expiration()}.
+fetch(Options) ->
+  RoleArn = os:getenv("AWS_ROLE_ARN"),
+  TokenFile = os:getenv("AWS_WEB_IDENTITY_TOKEN_FILE"),
+  AuthToken = read_token(TokenFile),
+  SessionName = maps:get(role_session_name, Options, ?DEFAULT_SESSION_NAME),
+  Response = fetch_assume_role_token(RoleArn, AuthToken, SessionName),
+  make_map(Response).
+
+-spec read_token(false | string()) -> {error, _} | {ok, binary()}.
+read_token(false) -> {error, no_credentials};
+read_token(Path) -> file:read_file(Path).
+
+-spec fetch_assume_role_token(false | string(), {error, _} | {ok, binary()}, binary()) ->
+        {error, _}
+      | {ok, aws_credentials_httpc:status_code(),
+              aws_credentials_httpc:body(),
+              aws_credentials_httpc:headers()}.
+fetch_assume_role_token(false, _AuthToken, _SessionName) -> {error, no_credentials};
+fetch_assume_role_token(_RoleArn, {error, _Error} = Error, _SessionName) -> Error;
+fetch_assume_role_token(RoleArn, {ok, AuthToken}, SessionName) ->
+  Url = lists:flatten(io_lib:format(?ASSUME_ROLE_URL, [RoleArn, AuthToken, SessionName])),
+  aws_credentials_httpc:request(get, Url).
+
+-spec make_map({error, _}
+| {ok, aws_credentials_httpc:status_code(),
+                    aws_credentials_httpc:body(),
+                    aws_credentials_httpc:headers()}) ->
+        {error, _}
+      | {ok, aws_credentials:credentials(), aws_credentials_provider:expiration()}.
+make_map({error, _Error} = Error) -> Error;
+make_map({ok, _Status, Body, _Headers}) ->
+  {Doc, []} = xmerl_scan:string(binary_to_list(Body)),
+  [#xmlText{value = AccessKeyId}] = xmerl_xpath:string("//Credentials/AccessKeyId/text()", Doc),
+  [#xmlText{value = SecretAccessKey}] =
+    xmerl_xpath:string("//Credentials/SecretAccessKey/text()", Doc),
+  [#xmlText{value = Token}] = xmerl_xpath:string("//Credentials/SessionToken/text()", Doc),
+  [#xmlText{value = Expiration}] = xmerl_xpath:string("//Credentials/Expiration/text()", Doc),
+  Creds = aws_credentials:make_map(?MODULE,
+    list_to_binary(AccessKeyId),
+    list_to_binary(SecretAccessKey),
+    list_to_binary(Token)),
+  {ok, Creds, list_to_binary(Expiration)}.

--- a/test/aws_credentials_providers_SUITE_data/web_identity/token
+++ b/test/aws_credentials_providers_SUITE_data/web_identity/token
@@ -1,0 +1,1 @@
+dummy-web-identity-token


### PR DESCRIPTION
This PR adds a credential provider that can acquire credentials using the [Assume Role with Web Identity](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html#API_AssumeRoleWithWebIdentity_Examples) strategy. This enables authenticating to AWS services from systems configured to use [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) to get credentials.

It also solves https://github.com/aws-beam/aws_credentials/issues/55.

This solves the same problem as https://github.com/aws-beam/aws_credentials/pull/73, but this PR uses bare http rather than relying on the aws cli.

Co-authors: @slackersoft, @mattwynne

Licensing:
This contribution is made by employees of Mechanical Orchard, Inc. under the terms of the project’s license.