### PR TITLE
Support getting an expiration from a credential process helper

### DIFF
--- a/test/aws_credentials_providers_SUITE_data/credential_process/credentials
+++ b/test/aws_credentials_providers_SUITE_data/credential_process/credentials
@@ -1,2 +1,2 @@
 [default]
-credential_process = echo '{"AccessKeyId":"dummy_access_key2", "SecretAccessKey":"dummy_secret_access_key2"}'
+credential_process = echo '{"AccessKeyId":"dummy_access_key2", "SecretAccessKey":"dummy_secret_access_key2", "Expiration": "2026-09-25T23:43:56"}'


### PR DESCRIPTION
I was looking to integrate iam identity center with aws_credentials, however that was a much bigger task then I wanted to initially take on today. The alternative I found was to export credentials from an sso profile. This would get killed though if it lasted for a while as we were ignoring the expiration. 

The credential process in aws supports returning the expiration as specified [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html).

This simply adds support for that specific case.