### PR TITLE
Make sure the update callback timeout is valid - erlang:send_after cr…

### DIFF
--- a/src/aws_credentials.erl
+++ b/src/aws_credentials.erl
@@ -221,9 +221,15 @@ setup_update_callback(Expires) when is_binary(Expires) ->
 setup_update_callback(Expires) when is_integer(Expires) ->
     setup_callback(Expires - ?ALERT_BEFORE_EXPIRY).
 
--spec setup_callback(pos_integer()) -> reference().
+-spec setup_callback(integer()) -> reference().
 setup_callback(Seconds) ->
-    erlang:send_after(Seconds * 1000, self(), refresh_credentials).
+    erlang:send_after(timeout(Seconds) * 1000, self(), refresh_credentials).
+
+-spec timeout(integer()) -> pos_integer().
+timeout(Seconds) when is_integer(Seconds), Seconds >= 0 ->
+    Seconds;
+timeout(_) ->
+    ?RETRY_DELAY.
 
 -spec seconds_until_timestamp(binary()) -> integer().
 seconds_until_timestamp(Timestamp) ->


### PR DESCRIPTION
…ashes if provided a negative value

During the AWS outage today, the aws_credentials app ultimately was terminated because the supervisor reached the max restart intensity. The crash that was causing the restarts was:

```,[{erlang,send_after,[-1000,<0.2314.0>,refresh_credentials],[{error_info,#{cause => time,module => erl_erts_errors}}]},{aws_credentials,setup_callback,1,```

Unfortunately, the actual value being returned for the expiration during this period was not in the stack trace. I'm sure this is an exceptional case but if the app were to remain running, it could, in theory recover once the service disruption is over. 
