### PR TITLE
Re-order the default credential providers to reduce logs and latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ sources in the following default order:
 2. OS environment variables
 3. An AWS [credentials file][1]
 4. ECS task credentials
-5. EC2 metadata
-6. EKS Pod Identity
-7. Web Identity
+5. EKS Pod Identity
+6. Web Identity
+7. EC2 metadata
 
 Usage
 -----

--- a/src/aws_credentials_provider.erl
+++ b/src/aws_credentials_provider.erl
@@ -35,9 +35,9 @@
 -type provider() :: aws_credentials_env
                   | aws_credentials_file
                   | aws_credentials_ecs
-                  | aws_credentials_ec2
                   | aws_credentials_eks
                   | aws_credentials_web_identity
+                  | aws_credentials_ec2
                   | module().
 -type error_log() :: [{provider(), term()}].
 -export_type([ options/0, expiration/0, provider/0, error_log/0 ]).
@@ -50,9 +50,9 @@
 -define(DEFAULT_PROVIDERS, [aws_credentials_env,
                             aws_credentials_file,
                             aws_credentials_ecs,
-                            aws_credentials_ec2,
                             aws_credentials_eks,
-                            aws_credentials_web_identity]).
+                            aws_credentials_web_identity,
+                            aws_credentials_ec2]).
 
 -spec fetch() ->
         {ok, aws_credentials:credentials(), expiration()} |


### PR DESCRIPTION
This PR re-orders the default providers to solve a nuisance we've experienced using the eks or web_identity providers: the EC2 provider must time out before it will try using the next provider and we don't expect it to succeed.

We could certainly solve this by overriding the default providers, but it's nice to not have to in the default case.

The EC2 provider uniquely has to make network requests even when not configured to determine failure, whereas all the other providers can quickly fail due to missing config. This generates delay and log noise when using one of the providers listed after EC2. Reordering them should continue to be fast for all providers including EC2, and improve the performance for eks and web_identity.

Co-author: @slackersoft

Licensing:
This contribution is made by employees of Mechanical Orchard, Inc. under the terms of the project’s license.