### PR TITLE
Web identity provider better handles error API responses

### DIFF
--- a/src/aws_credentials_web_identity.erl
+++ b/src/aws_credentials_web_identity.erl
@@ -46,13 +46,28 @@ fetch_assume_role_token(RoleArn, {ok, AuthToken}, SessionName) ->
   aws_credentials_httpc:request(get, Url).
 
 -spec make_map({error, _}
-| {ok, aws_credentials_httpc:status_code(),
+            | {ok, aws_credentials_httpc:status_code(),
                     aws_credentials_httpc:body(),
                     aws_credentials_httpc:headers()}) ->
         {error, _}
       | {ok, aws_credentials:credentials(), aws_credentials_provider:expiration()}.
 make_map({error, _Error} = Error) -> Error;
-make_map({ok, _Status, Body, _Headers}) ->
+make_map({ok, Status, Body, Headers}) ->
+  handle_response(Status, Body, Headers).
+
+-spec handle_response(aws_credentials_httpc:status_code(),
+                      aws_credentials_httpc:body(),
+                      aws_credentials_httpc:headers()) ->
+        {error, _}
+      | {ok, aws_credentials:credentials(), aws_credentials_provider:expiration()}.
+handle_response(200, Body, _Headers) ->
+  parse_credentials(Body);
+handle_response(Status, Body, Headers) ->
+  {error, build_error_payload(Status, Body, Headers)}.
+
+-spec parse_credentials(aws_credentials_httpc:body()) ->
+        {ok, aws_credentials:credentials(), aws_credentials_provider:expiration()}.
+parse_credentials(Body) ->
   {Doc, []} = xmerl_scan:string(binary_to_list(Body)),
   [#xmlText{value = AccessKeyId}] = xmerl_xpath:string("//Credentials/AccessKeyId/text()", Doc),
   [#xmlText{value = SecretAccessKey}] =
@@ -64,3 +79,32 @@ make_map({ok, _Status, Body, _Headers}) ->
     list_to_binary(SecretAccessKey),
     list_to_binary(Token)),
   {ok, Creds, list_to_binary(Expiration)}.
+
+-spec build_error_payload(aws_credentials_httpc:status_code(),
+                          aws_credentials_httpc:body(),
+                          aws_credentials_httpc:headers()) -> map().
+build_error_payload(Status, Body, _Headers) ->
+  try xmerl_scan:string(binary_to_list(Body)) of
+    {Doc, []} ->
+      #{ status => Status,
+        code => extract_code(Doc),
+        message => extract_error_message(Doc)
+      }
+  catch
+   _ ->
+    <<"unable to parse response as XML">>
+  end.
+
+-spec extract_code(XmlElement::any()) -> binary().
+extract_code(Doc) ->
+  case xmerl_xpath:string("//*[local-name()='Code']/text()", Doc) of
+    [#xmlText{value = C}] -> list_to_binary(C);
+    _ -> <<"Unable to find error code in AssumeRoleWithWebIdentity response">>
+  end.
+
+-spec extract_error_message(XmlElement::any()) -> binary().
+extract_error_message(Doc) ->
+  case xmerl_xpath:string("//*[local-name()='Message']/text()", Doc) of
+    [#xmlText{value = Msg}] -> list_to_binary(Msg);
+    _ -> <<"Unable to find error message in AssumeRoleWithWebIdentity response">>
+  end.

--- a/test/aws_credentials_SUITE.erl
+++ b/test/aws_credentials_SUITE.erl
@@ -19,7 +19,7 @@ init_per_group(mecked_metadata, Config) ->
     Role = <<"aws-metadata-user">>,
     AccessKeyID = <<"AccessKeyID">>,
     SecretAccessKey = <<"SecretAccessKey">>,
-    Expiry = <<"2025-09-25T23:43:56Z">>,
+    Expiry = <<"2035-09-25T23:43:56Z">>,
     Region = <<"ap-southeast-1">>,
     Token = <<"token">>,
     Credentials = <<"{
@@ -29,7 +29,7 @@ init_per_group(mecked_metadata, Config) ->
       \"AccessKeyId\" : \"AccessKeyID\",
       \"SecretAccessKey\" : \"SecretAccessKey\",
       \"Token\" : \"token\",
-      \"Expiration\" : \"2025-09-25T23:43:56Z\"
+      \"Expiration\" : \"2035-09-25T23:43:56Z\"
     }">>,
     Document = <<"{
       \"instanceType\" : \"t2.micro\",

--- a/test/aws_credentials_providers_SUITE.erl
+++ b/test/aws_credentials_providers_SUITE.erl
@@ -24,6 +24,7 @@
 -define(DUMMY_SESSION_TOKEN, "dummy-session-token").
 -define(DUMMY_REGION, <<"us-east-1">>).
 -define(DUMMY_REGION2, <<"us-east-2">>).
+-define(DUMMY_EXPIRATION, <<"2035-09-25T23:43:56Z">>).
 
 all() ->
   [ {group, file}
@@ -38,6 +39,7 @@ all() ->
   , {group, eks}
   , {group, web_identity}
   , {group, web_identity_default_session_name}
+  , {group, web_identity_error}
   , {group, credential_process}
   ].
 
@@ -54,6 +56,7 @@ groups() ->
   , {eks, [], all_testcases()}
   , {web_identity, [], all_testcases()}
   , {web_identity_default_session_name, [], all_testcases()}
+  , {web_identity_error, [], all_testcases()}
   , {credential_process, [], all_testcases()}
   ].
 
@@ -81,6 +84,8 @@ init_per_group(GroupName, Config) ->
         init_group(credential_process, provider(file), credential_process, Config);
     web_identity_default_session_name = GroupName ->
         init_group(GroupName, provider(web_identity), GroupName, Config);
+    web_identity_error ->
+        init_group(web_identity_error, provider(web_identity), web_identity, Config);
     GroupName -> init_group(GroupName, Config)
   end.
 
@@ -135,6 +140,14 @@ assert_test(WebIdentity) when WebIdentity =:= web_identity;
   assert_values(?DUMMY_ACCESS_KEY, ?DUMMY_SECRET_ACCESS_KEY, Provider),
   #{token := Token} = aws_credentials:get_credentials(),
   ?assertEqual(<<"unused">>, Token);
+assert_test(web_identity_error) ->
+  ?assertEqual(undefined, aws_credentials:get_credentials()),
+  {error, [{_, {error, ErrorInfo}}]} =
+    aws_credentials_provider:fetch(),
+  #{status := 400, message := Message, code := Code} = ErrorInfo,
+  ExpectedMsg = <<"The web identity token that was passed is expired">>,
+  ?assertEqual(<<"InvalidIdentityToken">>, Code),
+  ?assertEqual(ExpectedMsg, Message);
 assert_test(GroupName) ->
   Provider = provider(GroupName),
   assert_values(?DUMMY_ACCESS_KEY, ?DUMMY_SECRET_ACCESS_KEY, Provider).
@@ -249,6 +262,19 @@ setup_provider(web_identity, Config) ->
   , env => [ {"AWS_ROLE_ARN", OldRoleArn}
   , {"AWS_WEB_IDENTITY_TOKEN_FILE", OldWebIdentityTokenFile}
   ]};
+setup_provider(web_identity_error, Config) ->
+  OldRoleArn = os:getenv("AWS_ROLE_ARN"),
+  OldWebIdentityTokenFile = os:getenv("AWS_WEB_IDENTITY_TOKEN_FILE"),
+  application:set_env(aws_credentials, fail_if_unavailable, false),
+  os:putenv("AWS_ROLE_ARN", "arg:aws:iam::123123123"),
+  os:putenv("AWS_WEB_IDENTITY_TOKEN_FILE", ?config(data_dir, Config) ++ "web_identity/token"),
+  meck:new(httpc, [no_link, passthrough]),
+  meck:expect(httpc, request, fun mock_httpc_request_web_identity_error/5),
+  #{ mocks => [httpc]
+   , env => [ {"AWS_ROLE_ARN", OldRoleArn}
+            , {"AWS_WEB_IDENTITY_TOKEN_FILE", OldWebIdentityTokenFile}
+            ]
+   };
 setup_provider(config_env, Config) ->
   Old = os:getenv("AWS_CONFIG_FILE"),
   os:putenv("AWS_CONFIG_FILE", ?config(data_dir, Config) ++ "env/config"),
@@ -283,6 +309,7 @@ setup_provider(_GroupName, _Config) ->
    }.
 
 teardown_provider(Context) ->
+  application:unset_env(aws_credentials, fail_if_unavailable),
   #{mocks := Mocks, env := Env} = Context,
   [meck:unload(Mock) || Mock <- Mocks],
   [maybe_put_env(Key, Value) || {Key, Value} <- Env],
@@ -301,7 +328,7 @@ mock_httpc_request_ec2(Method, Request, HTTPOptions, Options, Profile) ->
       {ok, response('document')};
     _ ->
       meck:passthrough([Method, Request, HTTPOptions, Options, Profile])
-end.
+  end.
 
 mock_httpc_request_ecs(Method, Request, HTTPOptions, Options, Profile) ->
   case Request of
@@ -343,9 +370,19 @@ mock_httpc_request_web_identity(Method, Request, HTTPOptions, Options, Profile) 
     _ ->
       meck:passthrough([Method, Request, HTTPOptions, Options, Profile])
   end.
+mock_httpc_request_web_identity_error(Method, {Url, Headers}, HTTPOptions, Options, Profile) ->
+  case string:find(Url, "sts.amazonaws.com") of
+    nomatch ->
+      meck:passthrough([Method, {Url, Headers}, HTTPOptions, Options, Profile]);
+    _ ->
+      {ok, response(400, 'web-identity-error')}
+  end.
 
 response(BodyTag) ->
-  StatusLine = {unused, 200, unused},
+  response(200, BodyTag).
+
+response(Status, BodyTag) ->
+  StatusLine = {"HTTP/1.1", Status, ""},
   Headers = [],
   Body = body(BodyTag),
   {StatusLine, Headers, Body}.
@@ -357,7 +394,7 @@ body('security-credentials') ->
 body('dummy-role') ->
   jsx:encode(#{ 'AccessKeyId' => ?DUMMY_ACCESS_KEY
               , 'SecretAccessKey' => ?DUMMY_SECRET_ACCESS_KEY
-              , 'Expiration' => <<"2026-09-25T23:43:56Z">>
+              , 'Expiration' => ?DUMMY_EXPIRATION
               , 'Token' => unused
               });
 body('document') ->
@@ -365,26 +402,35 @@ body('document') ->
 body('dummy-uri') ->
   jsx:encode(#{ 'AccessKeyId' => ?DUMMY_ACCESS_KEY
               , 'SecretAccessKey' => ?DUMMY_SECRET_ACCESS_KEY
-              , 'Expiration' => <<"2026-09-25T23:43:56Z">>
+              , 'Expiration' => ?DUMMY_EXPIRATION
               , 'Token' => unused
               });
 body('eks-credentials') ->
   jsx:encode(#{ 'AccessKeyId' => ?DUMMY_ACCESS_KEY
               , 'SecretAccessKey' => ?DUMMY_SECRET_ACCESS_KEY
-              , 'Expiration' => <<"2026-09-25T23:43:56Z">>
+              , 'Expiration' => ?DUMMY_EXPIRATION
               , 'Token' => unused
               });
 body('web-identity-credentials') ->
-  <<"<AssumeRoleWithWebIdentityResponse>
-    <AssumeRoleWithWebIdentityResult>
-      <Credentials>
-        <AccessKeyId>", ?DUMMY_ACCESS_KEY/binary, "</AccessKeyId>
-        <SecretAccessKey>", ?DUMMY_SECRET_ACCESS_KEY/binary, "</SecretAccessKey>
-        <SessionToken>unused</SessionToken>
-        <Expiration>2026-09-25T23:43:56Z</Expiration>
-      </Credentials>
-    </AssumeRoleWithWebIdentityResult>
-  </AssumeRoleWithWebIdentityResponse>">>.
+  <<"<AssumeRoleWithWebIdentityResponse>\n"
+    "  <AssumeRoleWithWebIdentityResult>\n"
+    "    <Credentials>\n"
+    "      <AccessKeyId>", ?DUMMY_ACCESS_KEY/binary, "</AccessKeyId>\n"
+    "      <SecretAccessKey>", ?DUMMY_SECRET_ACCESS_KEY/binary, "</SecretAccessKey>\n"
+    "      <SessionToken>unused</SessionToken>\n"
+    "      <Expiration>", ?DUMMY_EXPIRATION/binary, "</Expiration>\n"
+    "    </Credentials>\n"
+    "  </AssumeRoleWithWebIdentityResult>\n"
+    "</AssumeRoleWithWebIdentityResponse>">>;
+body('web-identity-error') ->
+  <<"<ErrorResponse xmlns=\"https://sts.amazonaws.com/doc/2011-06-15/\">\n"
+    "  <Error>\n"
+    "    <Type>User</Type>\n"
+    "    <Code>InvalidIdentityToken</Code>\n"
+    "    <Message>The web identity token that was passed is expired</Message>\n"
+    "  </Error>\n"
+    "  <RequestId>dummy-request-id</RequestId>\n"
+    "</ErrorResponse>">>.
 
 maybe_put_env(Key, false) ->
   os:unsetenv(Key);


### PR DESCRIPTION
Previously the make_map function could raise an error if the XML response didn't contain the expected AccessKeyId or SecretAccessKey, which is the case if you get an error response from the api. This replaces that exception with a returned error tuple, allowing subsequent providers to attempt to auth and for the gen_server to start correctly.

We also pushed a few test credential expiration dates 10 years into the future to prevent them failing for a while ;)

Co-author: @jb2sf

Licensing:
This contribution is made by employees of Mechanical Orchard, Inc. under the terms of the project’s license.