### PR TITLE
Fix precedence in env provider

### DIFF
--- a/src/aws_credentials_env.erl
+++ b/src/aws_credentials_env.erl
@@ -61,8 +61,8 @@ get_env([]) -> undefined;
 get_env([Head | Tail]) ->
     case {erlang_get_env(Head), os_getenv(Head)} of
         {undefined, false} -> get_env(Tail);
-        {EnvVar, false} -> list_to_binary(EnvVar);
-        {_,  OSVal} -> list_to_binary(OSVal)
+        {undefined,  OSVal} -> list_to_binary(OSVal);
+        {EnvVar, _} -> list_to_binary(EnvVar)
     end.
 
 -spec os_getenv(string()) -> false | string().

--- a/test/aws_credentials_providers_SUITE.erl
+++ b/test/aws_credentials_providers_SUITE.erl
@@ -35,6 +35,7 @@ all() ->
   , {group, ec2}
   , {group, env}
   , {group, application_env}
+  , {group, env_precedence}
   , {group, ecs}
   , {group, eks}
   , {group, web_identity}
@@ -52,6 +53,7 @@ groups() ->
   , {ec2, [], all_testcases()}
   , {env, [], all_testcases()}
   , {application_env, [], all_testcases()}
+  , {env_precedence, [], all_testcases()}
   , {ecs, [], all_testcases()}
   , {eks, [], all_testcases()}
   , {web_identity, [], all_testcases()}
@@ -80,6 +82,7 @@ init_per_group(GroupName, Config) ->
     credential_env -> init_group(credential_env, provider(file), credential_env, Config);
     profile_env -> init_group(profile_env, provider(file), config_credential, Config);
     application_env -> init_group(application_env, provider(env), application_env, Config);
+    env_precedence -> init_group(env_precedence, provider(env), env_precedence, Config);
     credential_process ->
         init_group(credential_process, provider(file), credential_process, Config);
     web_identity_default_session_name = GroupName ->
@@ -120,6 +123,9 @@ assert_test(config_env) ->
   Provider = provider(file),
   assert_values(?DUMMY_ACCESS_KEY, ?DUMMY_SECRET_ACCESS_KEY, Provider, ?DUMMY_REGION2);
 assert_test(application_env) ->
+  Provider = provider(env),
+  assert_values(?DUMMY_ACCESS_KEY, ?DUMMY_SECRET_ACCESS_KEY, Provider);
+assert_test(env_precedence) ->
   Provider = provider(env),
   assert_values(?DUMMY_ACCESS_KEY, ?DUMMY_SECRET_ACCESS_KEY, Provider);
 assert_test(credential_env) ->
@@ -302,6 +308,22 @@ setup_provider(application_env, _Config) ->
                      , binary_to_list(?DUMMY_SECRET_ACCESS_KEY)),
   #{ mocks => []
    , env => []
+   };
+setup_provider(env_precedence, _Config) ->
+  OldAccessKeyId = os:getenv("AWS_ACCESS_KEY_ID"),
+  OldSecretAccessKey = os:getenv("AWS_SECRET_ACCESS_KEY"),
+  os:putenv("AWS_ACCESS_KEY_ID", binary_to_list(?DUMMY_ACCESS_KEY2)),
+  os:putenv("AWS_SECRET_ACCESS_KEY", binary_to_list(?DUMMY_SECRET_ACCESS_KEY2)),
+  application:set_env(aws_credentials
+                     , aws_access_key_id
+                     , binary_to_list(?DUMMY_ACCESS_KEY)),
+  application:set_env(aws_credentials
+                     , aws_secret_access_key
+                     , binary_to_list(?DUMMY_SECRET_ACCESS_KEY)),
+  #{ mocks => []
+   , env => [ {"AWS_ACCESS_KEY_ID", OldAccessKeyId}
+            , {"AWS_SECRET_ACCESS_KEY", OldSecretAccessKey}
+            ]
    };
 setup_provider(_GroupName, _Config) ->
   #{ mocks => []


### PR DESCRIPTION
The README suggests Erlang application environment variables take precedence over OS environment variables, but the aws_credentials_env provider reverses that. This PR updates the provider to align with what's documented in the README.

## What's documented

> This is a library to retrieve AWS credentials from a variety of possible sources in the following default order:
> 
> 1. Erlang application environment variables
> 2. OS environment variables
> ...

## What's occurring

I'm coming from Elixir, so that's what I'm more familiar with.

In this script we set both system env vars and application config (Erlang env vars) for our credentials, and the `aws_credentials_env` provider gives us the credentials from the system env vars. Only when the system env vars are deleted does it fall back to the Erlang ones.

```ex
Mix.install(
  [aws_credentials: "~> 1.0.3"],
  config: [
    aws_credentials: [
      aws_access_key_id: ~c"erlang env key",
      aws_secret_access_key: ~c"erlang env secret"
    ]
  ],
  system_env: %{
    "AWS_ACCESS_KEY_ID" => "os env key",
    "AWS_SECRET_ACCESS_KEY" => "os env secret"
  }
)

:aws_credentials_env.fetch([])
# {:ok,
#  %{
#    access_key_id: "os env key",
#    credential_provider: :aws_credentials_env,
#    secret_access_key: "os env secret"
#  }, :infinity}

System.delete_env("AWS_ACCESS_KEY_ID")
System.delete_env("AWS_SECRET_ACCESS_KEY")

:aws_credentials_env.fetch([])
# {:ok,
#  %{
#    access_key_id: "erlang env key",
#    credential_provider: :aws_credentials_env,
#    secret_access_key: "erlang env secret"
#  }, :infinity}
```

## AI disclosure

I let AI write the test for me, but it appears to be in line with the other tests.