### PR TITLE
feat: add region support to web_identity provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,35 @@ Different credential providers may have other settings which you can use to
 change their behaviors.  See the documentation for each provider for more
 details.
 
+### Web Identity Provider ###
+
+The web identity provider is used for EKS workloads using IAM Roles for Service
+Accounts (IRSA) and other environments that provide web identity tokens.
+
+**Environment Variables:**
+- `AWS_ROLE_ARN` (required) - The ARN of the role to assume
+- `AWS_WEB_IDENTITY_TOKEN_FILE` (required) - Path to the OIDC token file
+- `AWS_REGION` (optional) - AWS region to include in credentials map (checked first)
+- `AWS_DEFAULT_REGION` (optional) - Fallback region if AWS_REGION not set
+
+**Region Handling:**
+
+The provider checks for region in environment variables and includes it in the
+credentials map if present. This is useful for applications that require region
+information alongside credentials. If neither environment variable is set,
+credentials are returned without a region field (maintaining backward
+compatibility).
+
+**Example in Kubernetes with IRSA:**
+
+```yaml
+env:
+  - name: AWS_REGION
+    value: "eu-west-1"
+  # AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE are automatically
+  # injected by the EKS IRSA webhook
+```
+
 License and copyright
 ---------------------
 This project is licensed under the terms of the Apache 2 license. It is a

--- a/src/aws_credentials_web_identity.erl
+++ b/src/aws_credentials_web_identity.erl
@@ -16,8 +16,21 @@
         "https://sts.amazonaws.com/?Action=AssumeRoleWithWebIdentity&Version=2011-06-15" ++
         "&RoleArn=~s&WebIdentityToken=~s&RoleSessionName=~s").
 -define(DEFAULT_SESSION_NAME, "erlang_aws_credentials").
+-define(AWS_REGION, ["AWS_REGION", "AWS_DEFAULT_REGION"]).
 
 -export([fetch/1]).
+
+-spec get_region() -> undefined | binary().
+get_region() ->
+    get_env(?AWS_REGION).
+
+-spec get_env([string()]) -> undefined | binary().
+get_env([]) -> undefined;
+get_env([Head | Tail]) ->
+    case os:getenv(Head) of
+        false -> get_env(Tail);
+        Val -> list_to_binary(Val)
+    end.
 
 -spec fetch(aws_credentials_provider:options()) ->
         {error, _}
@@ -74,10 +87,19 @@ parse_credentials(Body) ->
     xmerl_xpath:string("//Credentials/SecretAccessKey/text()", Doc),
   [#xmlText{value = Token}] = xmerl_xpath:string("//Credentials/SessionToken/text()", Doc),
   [#xmlText{value = Expiration}] = xmerl_xpath:string("//Credentials/Expiration/text()", Doc),
-  Creds = aws_credentials:make_map(?MODULE,
-    list_to_binary(AccessKeyId),
-    list_to_binary(SecretAccessKey),
-    list_to_binary(Token)),
+  Creds = case get_region() of
+    undefined ->
+      aws_credentials:make_map(?MODULE,
+        list_to_binary(AccessKeyId),
+        list_to_binary(SecretAccessKey),
+        list_to_binary(Token));
+    Region ->
+      aws_credentials:make_map(?MODULE,
+        list_to_binary(AccessKeyId),
+        list_to_binary(SecretAccessKey),
+        list_to_binary(Token),
+        Region)
+  end,
   {ok, Creds, list_to_binary(Expiration)}.
 
 -spec build_error_payload(aws_credentials_httpc:status_code(),

--- a/test/aws_credentials_providers_SUITE.erl
+++ b/test/aws_credentials_providers_SUITE.erl
@@ -41,6 +41,8 @@ all() ->
   , {group, web_identity}
   , {group, web_identity_default_session_name}
   , {group, web_identity_error}
+  , {group, web_identity_with_region}
+  , {group, web_identity_with_default_region}
   , {group, credential_process}
   ].
 
@@ -59,6 +61,8 @@ groups() ->
   , {web_identity, [], all_testcases()}
   , {web_identity_default_session_name, [], all_testcases()}
   , {web_identity_error, [], all_testcases()}
+  , {web_identity_with_region, [], [get_credentials]}
+  , {web_identity_with_default_region, [], [get_credentials]}
   , {credential_process, [], all_testcases()}
   ].
 
@@ -89,6 +93,10 @@ init_per_group(GroupName, Config) ->
         init_group(GroupName, provider(web_identity), GroupName, Config);
     web_identity_error ->
         init_group(web_identity_error, provider(web_identity), web_identity, Config);
+    web_identity_with_region ->
+        init_group(web_identity_with_region, provider(web_identity), web_identity, Config);
+    web_identity_with_default_region ->
+        init_group(web_identity_with_default_region, provider(web_identity), web_identity, Config);
     GroupName -> init_group(GroupName, Config)
   end.
 
@@ -154,6 +162,32 @@ assert_test(web_identity_error) ->
   ExpectedMsg = <<"The web identity token that was passed is expired">>,
   ?assertEqual(<<"InvalidIdentityToken">>, Code),
   ?assertEqual(ExpectedMsg, Message);
+assert_test(web_identity_with_region) ->
+  Provider = provider(web_identity),
+  #{ access_key_id := AccessKeyId
+   , credential_provider := CredentialProvider
+   , secret_access_key := SecretAccessKey
+   , token := Token
+   , region := Region
+   } = aws_credentials:get_credentials(),
+  ?assertEqual(?DUMMY_ACCESS_KEY, AccessKeyId),
+  ?assertEqual(?DUMMY_SECRET_ACCESS_KEY, SecretAccessKey),
+  ?assertEqual(Provider, CredentialProvider),
+  ?assertEqual(<<"unused">>, Token),
+  ?assertEqual(<<"us-west-2">>, Region);
+assert_test(web_identity_with_default_region) ->
+  Provider = provider(web_identity),
+  #{ access_key_id := AccessKeyId
+   , credential_provider := CredentialProvider
+   , secret_access_key := SecretAccessKey
+   , token := Token
+   , region := Region
+   } = aws_credentials:get_credentials(),
+  ?assertEqual(?DUMMY_ACCESS_KEY, AccessKeyId),
+  ?assertEqual(?DUMMY_SECRET_ACCESS_KEY, SecretAccessKey),
+  ?assertEqual(Provider, CredentialProvider),
+  ?assertEqual(<<"unused">>, Token),
+  ?assertEqual(<<"ap-southeast-1">>, Region);
 assert_test(GroupName) ->
   Provider = provider(GroupName),
   assert_values(?DUMMY_ACCESS_KEY, ?DUMMY_SECRET_ACCESS_KEY, Provider).
@@ -179,6 +213,10 @@ assert_values(DummyAccessKey, DummySecretAccessKey, Provider, DummyRegion) ->
   ?assertEqual(DummyRegion, Region).
 
 %% Helpers ====================================================================
+provider(web_identity_with_region) ->
+  aws_credentials_web_identity;
+provider(web_identity_with_default_region) ->
+  aws_credentials_web_identity;
 provider(GroupName) ->
   list_to_existing_atom("aws_credentials_" ++ atom_to_list(GroupName)).
 
@@ -279,6 +317,42 @@ setup_provider(web_identity_error, Config) ->
   #{ mocks => [httpc]
    , env => [ {"AWS_ROLE_ARN", OldRoleArn}
             , {"AWS_WEB_IDENTITY_TOKEN_FILE", OldWebIdentityTokenFile}
+            ]
+   };
+setup_provider(web_identity_with_region, Config) ->
+  OldRoleArn = os:getenv("AWS_ROLE_ARN"),
+  OldWebIdentityTokenFile = os:getenv("AWS_WEB_IDENTITY_TOKEN_FILE"),
+  OldRegion = os:getenv("AWS_REGION"),
+  os:putenv("AWS_ROLE_ARN", "arg:aws:iam::123123123"),
+  os:putenv("AWS_WEB_IDENTITY_TOKEN_FILE", ?config(data_dir, Config) ++ "web_identity/token"),
+  os:putenv("AWS_REGION", "us-west-2"),
+  meck:new(httpc, [no_link, passthrough]),
+  meck:expect(httpc, request, fun mock_httpc_request_web_identity/5),
+  #{ mocks => [httpc]
+   , env => [ {"AWS_ROLE_ARN", OldRoleArn}
+            , {"AWS_WEB_IDENTITY_TOKEN_FILE", OldWebIdentityTokenFile}
+            , {"AWS_REGION", OldRegion}
+            ]
+   };
+setup_provider(web_identity_with_default_region, Config) ->
+  OldRoleArn = os:getenv("AWS_ROLE_ARN"),
+  OldWebIdentityTokenFile = os:getenv("AWS_WEB_IDENTITY_TOKEN_FILE"),
+  OldRegion = os:getenv("AWS_REGION"),
+  OldDefaultRegion = os:getenv("AWS_DEFAULT_REGION"),
+  case OldRegion of
+    false -> ok;
+    _ -> os:unsetenv("AWS_REGION")
+  end,
+  os:putenv("AWS_ROLE_ARN", "arg:aws:iam::123123123"),
+  os:putenv("AWS_WEB_IDENTITY_TOKEN_FILE", ?config(data_dir, Config) ++ "web_identity/token"),
+  os:putenv("AWS_DEFAULT_REGION", "ap-southeast-1"),
+  meck:new(httpc, [no_link, passthrough]),
+  meck:expect(httpc, request, fun mock_httpc_request_web_identity/5),
+  #{ mocks => [httpc]
+   , env => [ {"AWS_ROLE_ARN", OldRoleArn}
+            , {"AWS_WEB_IDENTITY_TOKEN_FILE", OldWebIdentityTokenFile}
+            , {"AWS_REGION", OldRegion}
+            , {"AWS_DEFAULT_REGION", OldDefaultRegion}
             ]
    };
 setup_provider(config_env, Config) ->


### PR DESCRIPTION
The web_identity provider now checks AWS_REGION and AWS_DEFAULT_REGION environment variables and includes region in the credentials map when present.

This fixes compatibility with EKS IRSA environments where region is set but not included in STS AssumeRoleWithWebIdentity responses.

- Check AWS_REGION first, then AWS_DEFAULT_REGION (AWS SDK standard - essentially copied this approach from aws-sdk-go-v2)
- Backward compatible: returns credentials without region if env vars not set
- Add tests for region handling and precedence
- Update README with region configuration documentation

Tested this feature branch in my app that uses aws_credentials - works fine with it :)

Disclaimer: AI was used for this PR