### PR TITLE
Relax rebar3_lint version for Erlang 29 compatibility

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -1,48 +1,40 @@
-[{ elvis
- , [
-    { config,
-      [ #{ dirs    => ["src", "test"]
-         , filter  => "*.erl"
-         , ruleset => erl_files
-         , rules   => [ {elvis_style, operator_spaces, #{ rules => [ {right, ","}
-                                                                   , {left , "-"}
-                                                                   , {right, "+"}
-                                                                   , {left , "+"}
-                                                                   , {right, "*"}
-                                                                   , {left , "*"}
-                                                                   , {right, "--"}
-                                                                   , {left , "--"}
-                                                                   , {right, "++"}
-                                                                   , {left , "++"}
-                                                                   , {right, "->"}
-                                                                   , {left , "->"}
-                                                                   , {right, "=>"}
-                                                                   , {left , "=>"}
-                                                                   , {right, "<-"}
-                                                                   , {left , "<-"}
-                                                                   , {right, "<="}
-                                                                   , {left , "<="}
-                                                                   , {right, "||"}
-                                                                   , {left , "||"}
-                                                                   , {right, "!"}
-                                                                   , {left , "!"}
-                                                                   , {right, "=:="}
-                                                                   , {left , "=:="}
-                                                                   , {right, "=/="}
-                                                                   , {left , "=/="}
-                                                                   ]}}
-                      , {elvis_style, dont_repeat_yourself, #{ min_complexity => 15 }}
-                      , {elvis_text_style, line_length, #{limit => 100, skip_comments => whole_line}}
-                      ]
-         }
-      , #{ dirs    => ["."]
-         , filter  => "rebar.config"
-         , ruleset => rebar_config
-         }
-      , #{ dirs    => ["."]
-         , filter  => "elvis.config"
-         , ruleset => elvis_config
-         }
-      ]}
+[{ config,
+   [ #{ files   => ["src/*.erl", "test/*.erl"]
+      , ruleset => erl_files
+      , rules   => [ {elvis_style, operator_spaces, #{ rules => [ {right, ","}
+                                                                , {left , "-"}
+                                                                , {right, "+"}
+                                                                , {left , "+"}
+                                                                , {right, "*"}
+                                                                , {left , "*"}
+                                                                , {right, "--"}
+                                                                , {left , "--"}
+                                                                , {right, "++"}
+                                                                , {left , "++"}
+                                                                , {right, "->"}
+                                                                , {left , "->"}
+                                                                , {right, "=>"}
+                                                                , {left , "=>"}
+                                                                , {right, "<-"}
+                                                                , {left , "<-"}
+                                                                , {right, "<="}
+                                                                , {left , "<="}
+                                                                , {right, "||"}
+                                                                , {left , "||"}
+                                                                , {right, "!"}
+                                                                , {left , "!"}
+                                                                , {right, "=:="}
+                                                                , {left , "=:="}
+                                                                , {right, "=/="}
+                                                                , {left , "=/="}
+                                                                ]}}
+                   , {elvis_style, dont_repeat_yourself, #{ min_complexity => 15 }}
+                   , {elvis_text_style, max_line_length, #{limit => 100, skip_comments => whole_line}}
+                   , {elvis_style, no_invalid_dynamic_calls, #{ ignore => [aws_credentials_providers_SUITE] }}
+                   ]
+      }
+   , #{ files   => ["rebar.config"]
+      , ruleset => rebar_config
+      }
    ]}
 ].

--- a/rebar.config
+++ b/rebar.config
@@ -42,4 +42,4 @@
 
 {dialyzer, [{plt_extra_apps, [xmerl]}]}.
 
-{plugins, [ {rebar3_lint, "3.0.1"} ]}.
+{plugins, [ {rebar3_lint, "~> 5.0"} ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -42,4 +42,4 @@
 
 {dialyzer, [{plt_extra_apps, [xmerl]}]}.
 
-{plugins, [ {rebar3_lint, "~> 5.0"} ]}.
+{plugins, [ {rebar3_lint, "~> 3.2"} ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -42,4 +42,4 @@
 
 {dialyzer, [{plt_extra_apps, [xmerl]}]}.
 
-{plugins, [ {rebar3_lint, "~> 3.2"} ]}.
+{plugins, [ {rebar3_lint, "~> 5.0"} ]}.


### PR DESCRIPTION
Projects making releases on Erlang 29 were failing with the old katana-code version.

Fixes: https://github.com/aws-beam/aws_credentials/issues/98