### PR TITLE
safely report error in credential_process with stdout cannot be decoded

### DIFF
--- a/src/aws_credentials_file.erl
+++ b/src/aws_credentials_file.erl
@@ -138,34 +138,37 @@ read_from_profile(File, Profile) ->
         undefined -> {error, {desired_profile_not_found, Profile}};
         Map ->
             case maps:is_key(<<"credential_process">>, Map) of
-                true ->
-                    % Source credentials with an external process
-                    % https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-sourcing-external.html
-                    Process = maps:get(<<"credential_process">>, Map),
-                    Stdout = os:cmd(binary_to_list(Process)),
-                    case decode_credential_process_output(Stdout) of
-                        {error, _} = Error ->
-                            Error;
-                        {ok, CredResult} ->
-                            CredsMap = maps:from_list(lists:filtermap(
-                                fun
-                                    ({<<"AccessKeyId">>, AKI}) ->
-                                        {true, {<<"aws_access_key_id">>, AKI}};
-                                    ({<<"SecretAccessKey">>, SAK}) ->
-                                        {true, {<<"aws_secret_access_key">>, SAK}};
-                                    ({<<"SessionToken">>, ST}) ->
-                                        {true, {<<"aws_session_token">>, ST}};
-                                    ({<<"Expiration">>, E}) ->
-                                        {true, {<<"aws_expiration">>, E}};
-                                    (_) ->
-                                        false
-                                end, maps:to_list(CredResult))),
-                            {ok, maps:merge(Map, CredsMap)}
-                    end;
-                false ->
-                    {ok, Map}
+                true -> resolve_credential_process(Map);
+                false -> {ok, Map}
             end
     end.
+
+%% Source credentials with an external process
+%% https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-sourcing-external.html
+-spec resolve_credential_process(map()) -> {error, any()} | {ok, map()}.
+resolve_credential_process(Map) ->
+    Process = maps:get(<<"credential_process">>, Map),
+    Stdout = os:cmd(binary_to_list(Process)),
+    case decode_credential_process_output(Stdout) of
+        {error, _} = Error ->
+            Error;
+        {ok, CredResult} ->
+            CredsMap = maps:from_list(lists:filtermap(
+                fun credential_process_field/1, maps:to_list(CredResult))),
+            {ok, maps:merge(Map, CredsMap)}
+    end.
+
+-spec credential_process_field({binary(), any()}) -> {true, {binary(), any()}} | false.
+credential_process_field({<<"AccessKeyId">>, AKI}) ->
+    {true, {<<"aws_access_key_id">>, AKI}};
+credential_process_field({<<"SecretAccessKey">>, SAK}) ->
+    {true, {<<"aws_secret_access_key">>, SAK}};
+credential_process_field({<<"SessionToken">>, ST}) ->
+    {true, {<<"aws_session_token">>, ST}};
+credential_process_field({<<"Expiration">>, E}) ->
+    {true, {<<"aws_expiration">>, E}};
+credential_process_field(_) ->
+    false.
 
 -spec decode_credential_process_output(iodata()) -> {error, any()} | {ok, map()}.
 decode_credential_process_output(Stdout) ->

--- a/src/aws_credentials_file.erl
+++ b/src/aws_credentials_file.erl
@@ -143,24 +143,37 @@ read_from_profile(File, Profile) ->
                     % https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-sourcing-external.html
                     Process = maps:get(<<"credential_process">>, Map),
                     Stdout = os:cmd(binary_to_list(Process)),
-                    CredResult = jsx:decode(iolist_to_binary(Stdout)),
-                    CredsMap = maps:from_list(lists:filtermap(
-                        fun
-                            ({<<"AccessKeyId">>, AKI}) ->
-                                {true, {<<"aws_access_key_id">>, AKI}};
-                            ({<<"SecretAccessKey">>, SAK}) ->
-                                {true, {<<"aws_secret_access_key">>, SAK}};
-                            ({<<"SessionToken">>, ST}) ->
-                                {true, {<<"aws_session_token">>, ST}};
-                            ({<<"Expiration">>, E}) ->
-                                {true, {<<"aws_expiration">>, E}};
-                            (_) ->
-                                false
-                        end, maps:to_list(CredResult))),
-                    {ok, maps:merge(Map, CredsMap)};
+                    case decode_credential_process_output(Stdout) of
+                        {error, _} = Error ->
+                            Error;
+                        {ok, CredResult} ->
+                            CredsMap = maps:from_list(lists:filtermap(
+                                fun
+                                    ({<<"AccessKeyId">>, AKI}) ->
+                                        {true, {<<"aws_access_key_id">>, AKI}};
+                                    ({<<"SecretAccessKey">>, SAK}) ->
+                                        {true, {<<"aws_secret_access_key">>, SAK}};
+                                    ({<<"SessionToken">>, ST}) ->
+                                        {true, {<<"aws_session_token">>, ST}};
+                                    ({<<"Expiration">>, E}) ->
+                                        {true, {<<"aws_expiration">>, E}};
+                                    (_) ->
+                                        false
+                                end, maps:to_list(CredResult))),
+                            {ok, maps:merge(Map, CredsMap)}
+                    end;
                 false ->
                     {ok, Map}
             end
+    end.
+
+-spec decode_credential_process_output(iodata()) -> {error, any()} | {ok, map()}.
+decode_credential_process_output(Stdout) ->
+    try jsx:decode(iolist_to_binary(Stdout)) of
+        Decoded when is_map(Decoded) -> {ok, Decoded};
+        _NotAMap -> {error, {invalid_credential_process_output, Stdout}}
+    catch
+        error:_ -> {error, {invalid_credential_process_output, Stdout}}
     end.
 
 -spec desired_profile(aws_credentials_provider:options()) -> binary().

--- a/test/aws_credentials_providers_SUITE.erl
+++ b/test/aws_credentials_providers_SUITE.erl
@@ -42,6 +42,7 @@ all() ->
   , {group, web_identity_default_session_name}
   , {group, web_identity_error}
   , {group, credential_process}
+  , {group, credential_process_invalid_json}
   ].
 
 groups() ->
@@ -60,6 +61,7 @@ groups() ->
   , {web_identity_default_session_name, [], all_testcases()}
   , {web_identity_error, [], all_testcases()}
   , {credential_process, [], all_testcases()}
+  , {credential_process_invalid_json, [], all_testcases()}
   ].
 
 all_testcases() ->
@@ -85,6 +87,9 @@ init_per_group(GroupName, Config) ->
     env_precedence -> init_group(env_precedence, provider(env), env_precedence, Config);
     credential_process ->
         init_group(credential_process, provider(file), credential_process, Config);
+    credential_process_invalid_json ->
+        init_group(credential_process_invalid_json, provider(file),
+                   credential_process_invalid_json, Config);
     web_identity_default_session_name = GroupName ->
         init_group(GroupName, provider(web_identity), GroupName, Config);
     web_identity_error ->
@@ -137,6 +142,12 @@ assert_test(profile_env) ->
 assert_test(credential_process) ->
   Provider = provider(file),
   assert_values(?DUMMY_ACCESS_KEY2, ?DUMMY_SECRET_ACCESS_KEY2, Provider);
+assert_test(credential_process_invalid_json) ->
+  ?assertEqual(undefined, aws_credentials:get_credentials()),
+  {ok, ProviderOpts} = application:get_env(aws_credentials, provider_options),
+  ?assertMatch(
+     {error, [{aws_credentials_file, {error, {invalid_credential_process_output, _}}}]},
+     aws_credentials_provider:fetch(ProviderOpts));
 assert_test(eks) ->
   Provider = provider(eks),
   assert_values(?DUMMY_ACCESS_KEY, ?DUMMY_SECRET_ACCESS_KEY, Provider);
@@ -190,6 +201,8 @@ provider_opts(credential_env, _Config) ->
   #{credential_path => os:getenv("HOME")};
 provider_opts(credential_process, Config) ->
   #{credential_path => ?config(data_dir, Config) ++ "credential_process/"};
+provider_opts(credential_process_invalid_json, Config) ->
+  #{credential_path => ?config(data_dir, Config) ++ "credential_process_invalid_json/"};
 provider_opts(web_identity, _Config) ->
   #{role_session_name => "overridden"};
 provider_opts(_GroupName, _Config) ->

--- a/test/aws_credentials_providers_SUITE_data/credential_process_invalid_json/credentials
+++ b/test/aws_credentials_providers_SUITE_data/credential_process_invalid_json/credentials
@@ -1,0 +1,2 @@
+[default]
+credential_process = echo 'not valid json'


### PR DESCRIPTION
I am using `credential_process` to get credentials, but if the stdout is not an encoded map, the decode will raise and cause a cryptic failure:
```
19:02:51.792 pid=<0.229.0> module=aws_credentials [info] aws_credentials ignoring exception :error::badarg ([
  {:jsx_decoder, :value, 4,
   [file: ~c"path/deps/jsx/src/jsx_decoder.erl", line: 234]},
  {:aws_credentials_file, :read_from_profile, 2,
   [
     file: ~c"path/deps/aws_credentials/src/aws_credentials_file.erl",
     line: 148
   ]},
  {:aws_credentials_file, :parse_credentials_file, 2,
   [
     file: ~c"path/deps/aws_credentials/src/aws_credentials_file.erl",
     line: 108
   ]},
  {:aws_credentials_file, :fetch, 1,
   [
     file: ~c"path/deps/aws_credentials/src/aws_credentials_file.erl",
     line: 45
   ]},
  {:aws_credentials_provider, :evaluate_providers, 3,
   [
     file: ~c"path/deps/aws_credentials/src/aws_credentials_provider.erl",
     line: 77
   ]},
  {:aws_credentials, :fetch_credentials, 1,
   [
     file: ~c"path/deps/aws_credentials/src/aws_credentials.erl",
     line: 177
   ]},
  {:aws_credentials, :init, 1,
   [
     file: ~c"path/deps/aws_credentials/src/aws_credentials.erl",
     line: 123
   ]},
  {:gen_server, :init_it, 2, [file: ~c"gen_server.erl", line: 2229]}
])
```

This PR adds a try/catch to that input, and will show the input if the decode fails:
```
19:22:36.859 pid=<0.229.0> module=aws_credentials [error] Provider :aws_credentials_env reports {:error, :environment_credentials_unavailable}
19:22:36.861 pid=<0.229.0> module=aws_credentials [error] Provider :aws_credentials_file reports {:error, {:invalid_credential_process_output, ~c"Touch your YubiKey..."}}
```