### PR TITLE
Make alert_before_expiry configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,13 @@ refresh credentials.
 When credentials have been found, they will be cached in a gen_server until the
 credential's expiration time. 5 minutes before expiration time the gen_server
 will attempt to acquire new credentials, so credentials will automatically be
-refreshed in the background.
+refreshed in the background. This 5 minute buffer can be overridden by setting
+the `alert_before_expiry` environment variable (in seconds) for
+`aws_credentials`:
+
+```erlang
+{aws_credentials, [{alert_before_expiry, 600}]}.
+```
 
 ### Choosing certain credentials providers ###
 

--- a/src/aws_credentials.erl
+++ b/src/aws_credentials.erl
@@ -9,8 +9,10 @@
 %% http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-metadata-security-credentials
 %%
 %% We make new credentials available at least five minutes prior to the
-%% expiration of the old credentials.
--define(ALERT_BEFORE_EXPIRY, 300). % 5 minutes
+%% expiration of the old credentials. Override via the `alert_before_expiry'
+%% application environment variable (in seconds).
+-define(ALERT_BEFORE_EXPIRY,
+        application:get_env(aws_credentials, alert_before_expiry, 300)).
 -define(RETRY_DELAY, 5). % 5 seconds
 -define(GREGORIAN_TO_EPOCH_SECONDS, 62167219200).
 

--- a/test/aws_credentials_SUITE.erl
+++ b/test/aws_credentials_SUITE.erl
@@ -10,11 +10,22 @@
 -define(DOCUMENT_URL,
         "http://169.254.169.254/latest/dynamic/instance-identity/document").
 
-all() -> [{group, boot}].
+all() -> [{group, boot}, {group, config}].
 
 groups() -> [{boot, [],
-              [fail_boot, fail_noboot]}].
+              [fail_boot, fail_noboot]},
+             {config, [],
+              [alert_before_expiry_configurable]}].
 
+init_per_group(config, Config) ->
+    Expiry = <<"2035-09-25T23:43:56Z">>,
+    Credentials = aws_credentials:make_map(ec2_instance_metadata,
+                                            <<"AccessKeyID">>,
+                                            <<"SecretAccessKey">>),
+    meck:new(aws_credentials_ec2, [no_link, passthrough]),
+    meck:expect(aws_credentials_ec2, fetch, fun(_) -> {ok, Credentials, Expiry} end),
+    application:set_env(aws_credentials, alert_before_expiry, 60),
+    [{expiry, Expiry}|Config];
 init_per_group(mecked_metadata, Config) ->
     Role = <<"aws-metadata-user">>,
     AccessKeyID = <<"AccessKeyID">>,
@@ -66,6 +77,10 @@ init_per_group(boot, Config) ->
     meck:expect(aws_credentials_ec2, fetch, fun(_) -> error(mocked_bad) end),
     Config.
 
+end_per_group(config, Config) ->
+    application:unset_env(aws_credentials, alert_before_expiry),
+    meck:unload(aws_credentials_ec2),
+    Config;
 end_per_group(mecked_metadata, Config) ->
     meck:unload(aws_credentials_httpc),
     Config;
@@ -92,6 +107,7 @@ end_per_testcase(_, Config) ->
     Apps = ?config(apps, Config),
     lists:foreach(fun(App) -> ok = application:stop(App) end,
                   lists:reverse(Apps)),
+    meck:unload(aws_credentials_file),
     Config.
 
 fail_boot(_Config) ->
@@ -107,3 +123,16 @@ fail_noboot(_Config) ->
     application:set_env(aws_credentials, fail_if_unavailable, true),
     ?assertMatch({error, {aws_credentials, _}},
                  application:ensure_all_started(aws_credentials)).
+
+%% Gregorian seconds at the Unix epoch (1970-01-01), mirrors the module's
+%% internal constant for converting iso8601 timestamps to a countdown.
+-define(GREGORIAN_TO_EPOCH_SECONDS, 62167219200).
+
+alert_before_expiry_configurable(Config) ->
+    Expiry = ?config(expiry, Config),
+    ExpectedSeconds = calendar:datetime_to_gregorian_seconds(iso8601:parse(Expiry))
+                     - (erlang:system_time(seconds) + ?GREGORIAN_TO_EPOCH_SECONDS)
+                     - 60, %% alert_before_expiry set to 60 in init_per_group(config, _)
+    {state, _Credentials, Tref} = sys:get_state(aws_credentials),
+    RemainingSeconds = erlang:read_timer(Tref) div 1000,
+    ?assert(abs(RemainingSeconds - ExpectedSeconds) =< 2).


### PR DESCRIPTION
## Problem

The library refreshes credentials 5 minutes before expiry, and that window is hardcoded (`?ALERT_BEFORE_EXPIRY, 300`).

I'm using this library to retrieve a token used for a long-running file transfer. The transfer can take longer than 5 minutes, so the token can expire mid-transfer. Rather than forcing a fresh token fetch before every transfer job, I'd like to be able to widen the refresh window so I can guarantee no token is ever within X minutes of expiring — enough to cover the transfer's duration.

## Change

Exposes the refresh window via the `alert_before_expiry` application environment variable (in seconds), defaulting to the existing 300 (5 minutes) if unset:

```erlang
{aws_credentials, [{alert_before_expiry, 600}]}.
```

## Testing

- Added a CT test (`config` group in `aws_credentials_SUITE`) that sets `alert_before_expiry` to 60, mocks the EC2 provider with a known expiry, and asserts the scheduled refresh timer fires at `expiry - 60s`.
- Fixed a latent test leak found while adding this: the generic `end_per_testcase` never unloaded the `aws_credentials_file` meck, which corrupted `aws_credentials_providers_SUITE` when run in the same VM as the new test.
- `rebar3 compile`, `lint`, `eunit`, `ct`, `dialyzer`, and `xref` all pass.
- Updated README to document the new variable.